### PR TITLE
Added support for MCP over HTTP and SSE while preserving stdio connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,33 @@ mcp dev main.py
 
 Then access `http://127.0.0.1:6274` in your browser to test your MCP server interactively.
 
+### Transport Modes
+
+The MCP server supports multiple transport modes for different use cases:
+
+| Flag | Transport | Endpoints | Use Case |
+|------|-----------|-----------|----------|
+| (none) | stdio | stdin/stdout | Claude Desktop default |
+| `--sse` | SSE only | `/sse`, `/messages/` | Legacy clients |
+| `--streamable-http` | HTTP only | `/mcp` | Modern HTTP clients |
+| `--combined` | Both | All above | Maximum compatibility |
+
+**Running with combined transport (recommended for HTTP):**
+```bash
+uv run --with "mcp[cli]" main.py --combined
+```
+
+This starts the server on `http://127.0.0.1:8000` with both SSE and streamable-HTTP endpoints available.
+
+**Testing the endpoints:**
+```bash
+# Test streamable-http
+curl -X POST http://localhost:8000/mcp
+
+# Test SSE
+curl http://localhost:8000/sse
+```
+
 ### Connecting to Claude Desktop
 
 The simplest way to install your MCP server in Claude Desktop:
@@ -176,6 +203,17 @@ Or for manual installation:
         "run",
         "/absolute/path/to/main.py"
       ]
+    }
+  }
+}
+```
+
+For HTTP transport mode, configure Claude Desktop with:
+```json
+{
+  "mcpServers": {
+    "Revit Connector": {
+      "url": "http://localhost:8000/mcp"
     }
   }
 }

--- a/main.py
+++ b/main.py
@@ -1,11 +1,20 @@
 # -*- coding: utf-8 -*-
+import sys
 import httpx
+import anyio
 from mcp.server.fastmcp import FastMCP, Image, Context
 import base64
 from typing import Optional, Dict, Any, Union
 
 # Create a generic MCP server for interacting with Revit
-mcp = FastMCP("Revit MCP Server")
+# Use stateless_http=True and json_response=True for better compatibility
+mcp = FastMCP(
+    "Revit MCP Server", 
+    host="127.0.0.1", 
+    port=8000,
+    stateless_http=True,
+    json_response=True
+)
 
 # Configuration
 REVIT_HOST = "localhost"
@@ -61,5 +70,48 @@ from tools import register_tools
 register_tools(mcp, revit_get, revit_post, revit_image)
 
 
+async def run_combined_async():
+    """Run server with both SSE and streamable-http endpoints.
+
+    This allows clients to connect via either:
+    - SSE: GET /sse, POST /messages/
+    - Streamable-HTTP: POST/GET /mcp
+    """
+    import uvicorn
+
+    # Get the streamable-http app first - it has the proper lifespan
+    # that initializes the session manager's task group
+    http_app = mcp.streamable_http_app()
+
+    # Get SSE routes (SSE doesn't need special lifespan - it creates
+    # task groups per-request in connect_sse())
+    sse_app = mcp.sse_app()
+
+    # Add SSE routes to the http app (preserving its lifespan)
+    for route in sse_app.routes:
+        http_app.routes.append(route)
+
+    config = uvicorn.Config(
+        http_app,
+        host=mcp.settings.host,
+        port=mcp.settings.port,
+        log_level=mcp.settings.log_level.lower(),
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    transport = "stdio"
+
+    if "--sse" in sys.argv:
+        transport = "sse"
+    elif "--http" in sys.argv or "--streamable-http" in sys.argv:
+        transport = "streamable-http"
+    elif "--combined" in sys.argv:
+        # Run both SSE and streamable-http transports simultaneously
+        print("Starting combined server with SSE (/sse, /messages/) and streamable-http (/mcp) endpoints...")
+        anyio.run(run_combined_async)
+        sys.exit(0)
+
+    mcp.run(transport=transport)


### PR DESCRIPTION
This pull request improves the MCP server by adding support for multiple transport modes, enhancing HTTP compatibility, and improving error handling for encoding issues. The documentation is updated to reflect these new capabilities and provide clear instructions for setup and testing.

**Transport mode enhancements:**
- Added support for multiple transport modes (stdio, SSE, streamable HTTP, and combined) in `main.py`, allowing clients to choose the most suitable protocol. The server can now be started in a "combined" mode to support both SSE and HTTP endpoints simultaneously.
- Updated the documentation in `README.md` to describe the new transport modes, how to run the server in combined mode, and how to test the endpoints.

**HTTP compatibility improvements:**
- Modified the initialization of `FastMCP` in `main.py` to enable `stateless_http` and `json_response` for better compatibility with HTTP clients.
- Added a configuration example to `README.md` for connecting Claude Desktop to the MCP server using the HTTP transport mode.

**Error handling improvements:**
- Improved request data parsing in `revit_mcp/code_execution.py` to explicitly handle both string and bytes data, ensuring robust decoding for HTTP requests.
- Enhanced error reporting in `revit_mcp/code_execution.py` to provide specific suggestions when encoding errors occur, such as missing .NET CodePages registration.