### PR TITLE
Fix empty error responses and optimize view element queries

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,25 +44,31 @@ async def revit_image(endpoint: str, ctx: Context = None) -> Union[Image, str]:
                 return Image(data=image_bytes, format="png")
             else:
                 return f"Error: {response.status_code} - {response.text}"
+    except httpx.TimeoutException:
+        return "Error: Image export timed out after 60 seconds."
     except Exception as e:
-        return f"Error: {e}"
+        msg = str(e) or type(e).__name__
+        return f"Error: {msg}"
 
 
-async def _revit_call(method: str, endpoint: str, data: Dict = None, ctx: Context = None, 
+async def _revit_call(method: str, endpoint: str, data: Dict = None, ctx: Context = None,
                      timeout: float = 30.0, params: Dict = None) -> Union[Dict, str]:
     """Internal function handling all HTTP calls"""
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             url = f"{BASE_URL}{endpoint}"
-            
+
             if method == "GET":
                 response = await client.get(url, params=params)
             else:  # POST
                 response = await client.post(url, json=data, headers={"Content-Type": "application/json"})
-            
+
             return response.json() if response.status_code == 200 else f"Error: {response.status_code} - {response.text}"
+    except httpx.TimeoutException:
+        return f"Error: Request timed out after {timeout} seconds. The operation may still be running in Revit."
     except Exception as e:
-        return f"Error: {e}"
+        msg = str(e) or type(e).__name__
+        return f"Error: {msg}"
 
 
 # Register all tools BEFORE the main block

--- a/revit_mcp/views.py
+++ b/revit_mcp/views.py
@@ -8,8 +8,14 @@ from pyrevit import routes, revit, DB
 import tempfile
 import os
 import base64
+import json
 import logging
 from System.Collections.Generic import List
+
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urllib import unquote
 
 from utils import normalize_string, get_element_name, element_id_value
 
@@ -37,6 +43,9 @@ def register_views_routes(api):
                     data={"error": "No active Revit document"}, status=503
                 )
 
+            # Decode URL-encoded characters (e.g. %20 -> space)
+            # httpx encodes the path but pyRevit's router doesn't decode params
+            view_name = unquote(view_name)
             # Normalize the view name
             view_name = normalize_string(view_name)
             logger.info("Exporting view: {}".format(view_name))
@@ -210,8 +219,6 @@ def register_views_routes(api):
                     data={"error": "No active Revit document"}, status=503
                 )
 
-            logger.info("Listing all exportable views")
-
             # Get all views
             all_views = DB.FilteredElementCollector(doc).OfClass(DB.View).ToElements()
 
@@ -368,17 +375,17 @@ def register_views_routes(api):
                 status=500,
             )
 
-    @api.route("/current_view_elements/", methods=["GET"])
-    def get_current_view_elements(doc, uidoc):
+    @api.route("/current_view_elements/", methods=["POST"])
+    def get_current_view_elements(doc, uidoc, request):
         """
         Get all elements visible in the current view.
 
-        Args:
-            doc: Revit document (provided by MCP context)
-            uidoc: UIDocument (provided by MCP context)
-
-        Returns:
-            dict: List of elements with detailed information
+        Expected JSON payload (all fields optional):
+        {
+            "limit": 5000,
+            "include_levels": false,
+            "include_location": false
+        }
         """
         try:
             if not doc or not uidoc:
@@ -392,110 +399,147 @@ def register_views_routes(api):
                     data={"error": "No active view found"}, status=404
                 )
 
-            logger.info("Getting elements in current view")
+            # Parse optional parameters from request body
+            limit = 5000
+            include_levels = False
+            include_location = False
+            try:
+                if request and request.data:
+                    data = (
+                        json.loads(request.data)
+                        if isinstance(request.data, str)
+                        else request.data
+                    )
+                    limit = int(data.get("limit", 5000))
+                    include_levels = bool(data.get("include_levels", False))
+                    include_location = bool(data.get("include_location", False))
+            except Exception:
+                pass  # Use defaults if parsing fails
 
             # Get all elements in the current view
             collector = DB.FilteredElementCollector(doc, current_view.Id)
             elements = collector.WhereElementIsNotElementType().ToElements()
 
-            # Process elements to get basic information
+            # Level cache to avoid redundant doc.GetElement() calls
+            level_cache = {}  # {int(level_id): {"name": str, "id": int}}
+
+            # Process elements, tracking category counts for ALL elements
             elements_info = []
+            category_counts = {}
+            total_elements = 0
+
             for elem in elements:
                 try:
+                    # Get category name for counting (always counted, even beyond limit)
+                    cat = elem.Category
+                    if cat:
+                        cat_name = cat.Name
+                    else:
+                        cat_name = "Unknown"
+
+                    if cat_name in category_counts:
+                        category_counts[cat_name] = category_counts[cat_name] + 1
+                    else:
+                        category_counts[cat_name] = 1
+                    total_elements = total_elements + 1
+
+                    # Only build full element info up to the limit
+                    if len(elements_info) >= limit:
+                        continue
+
                     element_info = {
                         "element_id": element_id_value(elem.Id),
                         "name": normalize_string(get_element_name(elem)),
-                        "element_type": elem.GetType().Name,
+                        "category": cat_name,
                     }
 
-                    # Add category information
-                    if elem.Category:
-                        element_info["category"] = elem.Category.Name
-                        element_info["category_id"] = element_id_value(elem.Category.Id)
+                    if cat:
+                        element_info["category_id"] = element_id_value(cat.Id)
                     else:
-                        element_info["category"] = "Unknown"
                         element_info["category_id"] = None
 
-                    # Add level information if available
-                    try:
-                        level_param = elem.get_Parameter(
-                            DB.BuiltInParameter.FAMILY_LEVEL_PARAM
-                        )
-                        if level_param:
-                            level_id = level_param.AsElementId()
-                            if level_id != DB.ElementId.InvalidElementId:
-                                level_elem = doc.GetElement(level_id)
-                                element_info["level"] = normalize_string(get_element_name(level_elem))
-                                element_info["level_id"] = element_id_value(level_id)
+                    # Add level information only if requested (opt-in)
+                    if include_levels:
+                        try:
+                            level_param = elem.get_Parameter(
+                                DB.BuiltInParameter.FAMILY_LEVEL_PARAM
+                            )
+                            if level_param:
+                                level_id = level_param.AsElementId()
+                                if level_id != DB.ElementId.InvalidElementId:
+                                    lid = element_id_value(level_id)
+                                    if lid in level_cache:
+                                        cached = level_cache[lid]
+                                        element_info["level"] = cached["name"]
+                                        element_info["level_id"] = cached["id"]
+                                    else:
+                                        level_elem = doc.GetElement(level_id)
+                                        lname = normalize_string(get_element_name(level_elem))
+                                        level_cache[lid] = {"name": lname, "id": lid}
+                                        element_info["level"] = lname
+                                        element_info["level_id"] = lid
+                                else:
+                                    element_info["level"] = None
+                                    element_info["level_id"] = None
                             else:
                                 element_info["level"] = None
                                 element_info["level_id"] = None
-                        else:
+                        except Exception:
                             element_info["level"] = None
                             element_info["level_id"] = None
-                    except Exception:
-                        element_info["level"] = None
-                        element_info["level_id"] = None
 
-                    # Add location information if available
-                    try:
-                        location = elem.Location
-                        if hasattr(location, "Point"):
-                            pt = location.Point
-                            element_info["location"] = {
-                                "type": "point",
-                                "x": pt.X,
-                                "y": pt.Y,
-                                "z": pt.Z,
-                            }
-                        elif hasattr(location, "Curve"):
-                            curve = location.Curve
-                            start = curve.GetEndPoint(0)
-                            end = curve.GetEndPoint(1)
-                            element_info["location"] = {
-                                "type": "curve",
-                                "start": {"x": start.X, "y": start.Y, "z": start.Z},
-                                "end": {"x": end.X, "y": end.Y, "z": end.Z},
-                            }
-                        else:
+                    # Add location information only if requested (opt-in)
+                    if include_location:
+                        try:
+                            location = elem.Location
+                            if hasattr(location, "Point"):
+                                pt = location.Point
+                                element_info["location"] = {
+                                    "type": "point",
+                                    "x": pt.X,
+                                    "y": pt.Y,
+                                    "z": pt.Z,
+                                }
+                            elif hasattr(location, "Curve"):
+                                curve = location.Curve
+                                start = curve.GetEndPoint(0)
+                                end = curve.GetEndPoint(1)
+                                element_info["location"] = {
+                                    "type": "curve",
+                                    "start": {"x": start.X, "y": start.Y, "z": start.Z},
+                                    "end": {"x": end.X, "y": end.Y, "z": end.Z},
+                                }
+                            else:
+                                element_info["location"] = {"type": "unknown"}
+                        except Exception:
                             element_info["location"] = {"type": "unknown"}
-                    except Exception:
-                        element_info["location"] = {"type": "unknown"}
 
                     elements_info.append(element_info)
 
                 except Exception as elem_error:
-                    # Skip elements that cause errors but log the issue
                     logger.warning(
-                        "Could not process element {}: {}".format(
-                            element_id_value(elem.Id) if elem else "Unknown", str(elem_error)
-                        )
+                        "Could not process element: {}".format(str(elem_error))
                     )
                     continue
 
-            # Group elements by category for easier analysis
-            elements_by_category = {}
-            for elem_info in elements_info:
-                category = elem_info["category"]
-                if category not in elements_by_category:
-                    elements_by_category[category] = []
-                elements_by_category[category].append(elem_info)
-
-            # Create summary statistics
-            category_counts = {
-                category: len(elements)
-                for category, elements in elements_by_category.items()
-            }
+            truncated = total_elements > len(elements_info)
 
             result = {
                 "status": "success",
                 "view_name": normalize_string(get_element_name(current_view)),
                 "view_id": element_id_value(current_view.Id),
-                "total_elements": len(elements_info),
+                "total_elements": total_elements,
+                "returned_elements": len(elements_info),
+                "limit": limit,
+                "truncated": truncated,
                 "elements": elements_info,
-                "elements_by_category": elements_by_category,
                 "category_counts": category_counts,
             }
+
+            if truncated:
+                result["message"] = "Results truncated: showing {} of {} elements. Use limit parameter to retrieve more.".format(
+                    len(elements_info), total_elements
+                )
 
             return routes.make_response(data=result)
 

--- a/tests/unit/test_document_tools.py
+++ b/tests/unit/test_document_tools.py
@@ -22,6 +22,7 @@ class TestOpenDocument:
             "/open_document/",
             {"file_path": "C:/test.rvt", "detach": False, "audit": False},
             None,
+            timeout=120.0,
         )
 
     async def test_open_detach_flag(self, doc_tools, mock_revit_post):
@@ -72,6 +73,7 @@ class TestSyncWithCentral:
             "/sync_with_central/",
             {"comment": "", "compact": False, "relinquish_all": True},
             None,
+            timeout=120.0,
         )
 
     async def test_sync_custom(self, doc_tools, mock_revit_post):

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -60,7 +60,7 @@ class TestViewTools:
 
     async def test_list_revit_views(self):
         await self.tools["list_revit_views"](ctx=None)
-        self.mock_get.assert_called_once_with("/list_views/", None)
+        self.mock_get.assert_called_once_with("/list_views/", None, timeout=120.0)
 
     async def test_get_revit_view(self):
         await self.tools["get_revit_view"](view_name="Level 1", ctx=None)
@@ -72,7 +72,7 @@ class TestViewTools:
 
     async def test_get_current_view_elements(self):
         await self.tools["get_current_view_elements"](ctx=None)
-        self.mock_get.assert_called_once_with("/current_view_elements/", None)
+        self.mock_get.assert_called_once_with("/current_view_elements/", None, timeout=120.0)
 
 
 # ---- Family tools ----
@@ -165,7 +165,7 @@ class TestColorTools:
     async def test_clear_colors(self):
         await self.tools["clear_colors"](category_name="Walls", ctx=None)
         self.mock_post.assert_called_once_with(
-            "/clear_colors/", {"category_name": "Walls"}, None
+            "/clear_colors/", {"category_name": "Walls"}, None, timeout=60.0
         )
 
     async def test_list_category_parameters(self):
@@ -200,6 +200,7 @@ class TestCodeExecutionTools:
             "/execute_code/",
             {"code": "print('hello')", "description": "Code execution"},
             None,
+            timeout=300.0,
         )
         assert result == "hello"
 

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -53,9 +53,11 @@ class TestViewTools:
     @pytest.fixture(autouse=True)
     def setup(self, mock_mcp, mock_revit_get, mock_revit_post, mock_revit_image):
         mock_revit_get.return_value = {"status": "success", "data": []}
+        mock_revit_post.return_value = {"status": "success", "elements": []}
         register_view_tools(mock_mcp, mock_revit_get, mock_revit_post, mock_revit_image)
         self.tools = mock_mcp.tools
         self.mock_get = mock_revit_get
+        self.mock_post = mock_revit_post
         self.mock_image = mock_revit_image
 
     async def test_list_revit_views(self):
@@ -72,7 +74,12 @@ class TestViewTools:
 
     async def test_get_current_view_elements(self):
         await self.tools["get_current_view_elements"](ctx=None)
-        self.mock_get.assert_called_once_with("/current_view_elements/", None, timeout=120.0)
+        self.mock_post.assert_called_once_with(
+            "/current_view_elements/",
+            {"limit": 5000, "include_levels": False, "include_location": False},
+            None,
+            timeout=120.0,
+        )
 
 
 # ---- Family tools ----

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -62,7 +62,7 @@ class TestViewTools:
 
     async def test_list_revit_views(self):
         await self.tools["list_revit_views"](ctx=None)
-        self.mock_get.assert_called_once_with("/list_views/", None, timeout=120.0)
+        self.mock_get.assert_called_once_with("/list_views/", None)
 
     async def test_get_revit_view(self):
         await self.tools["get_revit_view"](view_name="Level 1", ctx=None)
@@ -78,7 +78,6 @@ class TestViewTools:
             "/current_view_elements/",
             {"limit": 5000, "include_levels": False, "include_location": False},
             None,
-            timeout=120.0,
         )
 
 
@@ -172,7 +171,7 @@ class TestColorTools:
     async def test_clear_colors(self):
         await self.tools["clear_colors"](category_name="Walls", ctx=None)
         self.mock_post.assert_called_once_with(
-            "/clear_colors/", {"category_name": "Walls"}, None, timeout=60.0
+            "/clear_colors/", {"category_name": "Walls"}, None
         )
 
     async def test_list_category_parameters(self):
@@ -207,7 +206,7 @@ class TestCodeExecutionTools:
             "/execute_code/",
             {"code": "print('hello')", "description": "Code execution"},
             None,
-            timeout=300.0,
+            timeout=60.0,
         )
         assert result == "hello"
 

--- a/tools/code_execution_tools.py
+++ b/tools/code_execution_tools.py
@@ -47,7 +47,7 @@ def register_code_execution_tools(mcp, revit_get, revit_post, revit_image=None):
             if ctx:
                 await ctx.info("Executing code: {}".format(description))
 
-            response = await revit_post("/execute_code/", payload, ctx)
+            response = await revit_post("/execute_code/", payload, ctx, timeout=300.0)
             return format_response(response)
 
         except (ConnectionError, ValueError, RuntimeError) as e:

--- a/tools/code_execution_tools.py
+++ b/tools/code_execution_tools.py
@@ -47,7 +47,7 @@ def register_code_execution_tools(mcp, revit_get, revit_post, revit_image=None):
             if ctx:
                 await ctx.info("Executing code: {}".format(description))
 
-            response = await revit_post("/execute_code/", payload, ctx, timeout=300.0)
+            response = await revit_post("/execute_code/", payload, ctx, timeout=60.0)
             return format_response(response)
 
         except (ConnectionError, ValueError, RuntimeError) as e:

--- a/tools/colors_tools.py
+++ b/tools/colors_tools.py
@@ -50,7 +50,7 @@ def register_colors_tools(mcp, revit_get, revit_post, revit_image=None):
                         category_name, parameter_name
                     )
                 )
-            response = await revit_post("/color_splash/", data, ctx)
+            response = await revit_post("/color_splash/", data, ctx, timeout=120.0)
             return format_response(response)
 
         except Exception as e:
@@ -79,7 +79,7 @@ def register_colors_tools(mcp, revit_get, revit_post, revit_image=None):
 
             if ctx:
                 await ctx.info("Clearing color overrides for {} elements".format(category_name))
-            response = await revit_post("/clear_colors/", data, ctx)
+            response = await revit_post("/clear_colors/", data, ctx, timeout=60.0)
             return format_response(response)
 
         except Exception as e:

--- a/tools/colors_tools.py
+++ b/tools/colors_tools.py
@@ -50,7 +50,7 @@ def register_colors_tools(mcp, revit_get, revit_post, revit_image=None):
                         category_name, parameter_name
                     )
                 )
-            response = await revit_post("/color_splash/", data, ctx, timeout=120.0)
+            response = await revit_post("/color_splash/", data, ctx, timeout=60.0)
             return format_response(response)
 
         except Exception as e:
@@ -79,7 +79,7 @@ def register_colors_tools(mcp, revit_get, revit_post, revit_image=None):
 
             if ctx:
                 await ctx.info("Clearing color overrides for {} elements".format(category_name))
-            response = await revit_post("/clear_colors/", data, ctx, timeout=60.0)
+            response = await revit_post("/clear_colors/", data, ctx)
             return format_response(response)
 
         except Exception as e:

--- a/tools/document_tools.py
+++ b/tools/document_tools.py
@@ -31,7 +31,7 @@ def register_document_tools(mcp, revit_get, revit_post):
             "detach": detach,
             "audit": audit,
         }
-        response = await revit_post("/open_document/", data, ctx)
+        response = await revit_post("/open_document/", data, ctx, timeout=120.0)
         return format_response(response)
 
     @mcp.tool()
@@ -89,5 +89,5 @@ def register_document_tools(mcp, revit_get, revit_post):
             "compact": compact,
             "relinquish_all": relinquish_all,
         }
-        response = await revit_post("/sync_with_central/", data, ctx)
+        response = await revit_post("/sync_with_central/", data, ctx, timeout=120.0)
         return format_response(response)

--- a/tools/view_tools.py
+++ b/tools/view_tools.py
@@ -16,7 +16,7 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
     @mcp.tool()
     async def list_revit_views(ctx: Context = None) -> str:
         """Get a list of all exportable views in the current Revit model"""
-        response = await revit_get("/list_views/", ctx)
+        response = await revit_get("/list_views/", ctx, timeout=120.0)
         return format_response(response)
 
     @mcp.tool()
@@ -54,5 +54,5 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
         """
         if ctx:
             await ctx.info("Getting elements in current view...")
-        response = await revit_get("/current_view_elements/", ctx)
+        response = await revit_get("/current_view_elements/", ctx, timeout=120.0)
         return format_response(response)

--- a/tools/view_tools.py
+++ b/tools/view_tools.py
@@ -38,21 +38,32 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
         return format_response(response)
 
     @mcp.tool()
-    async def get_current_view_elements(ctx: Context = None) -> str:
+    async def get_current_view_elements(
+        limit: int = 5000,
+        include_levels: bool = False,
+        include_location: bool = False,
+        ctx: Context = None,
+    ) -> str:
         """
-        Get all elements visible in the currently active view in Revit.
+        Get elements visible in the currently active view in Revit.
 
-        Returns detailed information about each element including:
-        - Element ID, name, and type
-        - Category and category ID
-        - Level information (if applicable)
-        - Location information (point or curve)
-        - Summary statistics grouped by category
+        Returns per element: element_id, name, category, category_id.
+        Also returns category_counts (always for ALL elements, even if truncated).
 
-        This is useful for understanding what elements are currently visible
-        and analyzing the content of the active view.
+        If the response contains truncated=true, not all elements were returned.
+        Check total_elements vs returned_elements and increase limit if needed.
+
+        Args:
+            limit: Maximum number of elements to return (default 5000).
+            include_levels: Include level name and level_id per element. Default false.
+            include_location: Include location geometry (point or curve). Default false.
         """
         if ctx:
             await ctx.info("Getting elements in current view...")
-        response = await revit_get("/current_view_elements/", ctx, timeout=120.0)
+        data = {
+            "limit": limit,
+            "include_levels": include_levels,
+            "include_location": include_location,
+        }
+        response = await revit_post("/current_view_elements/", data, ctx, timeout=120.0)
         return format_response(response)

--- a/tools/view_tools.py
+++ b/tools/view_tools.py
@@ -16,7 +16,7 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
     @mcp.tool()
     async def list_revit_views(ctx: Context = None) -> str:
         """Get a list of all exportable views in the current Revit model"""
-        response = await revit_get("/list_views/", ctx, timeout=120.0)
+        response = await revit_get("/list_views/", ctx)
         return format_response(response)
 
     @mcp.tool()
@@ -65,5 +65,5 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
             "include_levels": include_levels,
             "include_location": include_location,
         }
-        response = await revit_post("/current_view_elements/", data, ctx, timeout=120.0)
+        response = await revit_post("/current_view_elements/", data, ctx)
         return format_response(response)


### PR DESCRIPTION
                                                                                   
Problem                                                                                                                                              
                                                                                                                                                       
  Several MCP tools (list_views, get_current_view_elements, get_revit_view) were failing silently or returning cryptic empty errors. Three separate    
  root causes were identified:                                                                                                                         
                                                                                                                                                       
  1. Timeout errors returned empty messages — httpx.TimeoutException was caught by the generic except Exception handler, and str(e) on a timeout
  exception returns an empty string, so users saw "Error: " with no explanation.
  2. get_current_view_elements was too slow — Returned all element data (levels, locations, .NET reflection calls) unconditionally, taking >120s for
  ~1600 elements and blocking Revit's UI thread.
  3. get_revit_view failed for view names with spaces — httpx URL-encodes the path (NIVEAU 1 → NIVEAU%201), but pyRevit's router doesn't decode path
  parameters, causing a 404 mismatch.

  Changes

  Error handling (main.py)
  - Add explicit httpx.TimeoutException handling with descriptive messages in both _revit_call and revit_image
  - Use str(e) or type(e).__name__ fallback so errors are never blank

  Performance (revit_mcp/views.py, tools/view_tools.py)
  - Change get_current_view_elements from GET to POST with a JSON body for parameters
  - Add limit (default 5000), include_levels (default false), include_location (default false) parameters
  - Make level and location data opt-in — default response is just element_id, name, category, category_id
  - Cache level lookups to avoid redundant doc.GetElement() calls
  - Remove expensive elem.GetType().Name reflection call
  - Always return category_counts and total_elements for all elements, even when truncated
  - Fix missing request parameter in the route handler (params were silently ignored)

  URL decoding (revit_mcp/views.py)
  - Add unquote() to decode URL-encoded view names before lookup

  Timeouts (tools/)
  - Set explicit timeouts for slow operations: execute_code (60s), color_splash (60s), open_document (120s), sync_with_central (120s)
  - Leave fast operations at the 30s default

  Tests
  - Update tool wrapper tests for new POST method, parameters, and timeout values