### PR TITLE
Add 16 new tools (incl. 9 README-pending) + Revit 2026 hardening

### DIFF
--- a/LLM.txt
+++ b/LLM.txt
@@ -510,6 +510,7 @@ Your Module for Revit MCP
 Handles your specific functionality.
 """
 from pyrevit import routes, revit, DB
+from System import Int64
 import json
 import logging
 
@@ -543,7 +544,9 @@ def register_your_routes(api):
             try:
                 element_id = data.get("element_id")
                 new_value = data.get("new_value")
-                element = doc.GetElement(DB.ElementId(int(element_id)))
+                # Revit 2026: cast through System.Int64 to disambiguate the
+                # ElementId(BuiltInParameter / BuiltInCategory / Int64) overloads.
+                element = doc.GetElement(DB.ElementId(Int64(int(element_id))))
                 
                 param = element.LookupParameter("Comments")
                 param.Set(new_value)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Your Module for Revit MCP
 Handles your specific functionality.
 """
 from pyrevit import routes, revit, DB
+from System import Int64
 import json
 import logging
 
@@ -309,7 +310,9 @@ def register_your_routes(api):
             try:
                 element_id = data.get("element_id")
                 new_value = data.get("new_value")
-                element = doc.GetElement(DB.ElementId(int(element_id)))
+                # Revit 2026: cast through System.Int64 to disambiguate the
+                # ElementId(BuiltInParameter / BuiltInCategory / Int64) overloads.
+                element = doc.GetElement(DB.ElementId(Int64(int(element_id))))
                 param = element.LookupParameter("Comments")
                 param.Set(new_value)
 

--- a/revit_mcp/annotation.py
+++ b/revit_mcp/annotation.py
@@ -1,0 +1,142 @@
+# -*- coding: UTF-8 -*-
+"""
+Annotation Module for Revit MCP
+Wall tagging in the active view.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def register_annotation_routes(api):
+    """Register annotation/tagging endpoints."""
+
+    @api.route("/tag_walls/", methods=["POST"])
+    def tag_walls(doc, request):
+        """
+        Tag every wall visible in the currently active plan view.
+
+        Expected payload (all optional):
+        {
+            "tag_family_name": "Wall Tag",    // default = first available wall tag symbol
+            "tag_type_name": "1/8\" Boxed",   // optional; first symbol of family if omitted
+            "leader": false,                   // attach a leader line?
+            "orientation": "horizontal"        // "horizontal" or "vertical"
+        }
+
+        Skips walls that already carry a tag of the chosen type in this view.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            uidoc = revit.uidoc
+            if not uidoc:
+                return routes.make_response(data={"error": "No active Revit UI document"}, status=503)
+            active_view = uidoc.ActiveView
+            if active_view is None:
+                return routes.make_response(data={"error": "No active view"}, status=503)
+            if active_view.ViewType not in (DB.ViewType.FloorPlan, DB.ViewType.CeilingPlan, DB.ViewType.EngineeringPlan, DB.ViewType.AreaPlan):
+                return routes.make_response(data={
+                    "error": "Active view must be a plan view (got: {}). Switch to a Floor Plan or Ceiling Plan and retry.".format(active_view.ViewType)
+                }, status=400)
+
+            data = _parse_json_request(request)
+            tag_family_name = data.get("tag_family_name")
+            tag_type_name = data.get("tag_type_name")
+            with_leader = bool(data.get("leader", False))
+            orientation_str = (data.get("orientation") or "horizontal").lower()
+            orientation = DB.TagOrientation.Horizontal if orientation_str == "horizontal" else DB.TagOrientation.Vertical
+
+            # Find a wall-tag family symbol
+            tag_symbols = (DB.FilteredElementCollector(doc)
+                           .OfCategory(DB.BuiltInCategory.OST_WallTags)
+                           .WhereElementIsElementType())
+            chosen_symbol = None
+            available = []
+            for sym in tag_symbols:
+                fam_name = sym.Family.Name if hasattr(sym, "Family") and sym.Family else u"?"
+                sym_name = sym.Name
+                available.append({"family": normalize_string(fam_name), "type": normalize_string(sym_name)})
+                if tag_family_name and fam_name != tag_family_name:
+                    continue
+                if tag_type_name and sym_name != tag_type_name:
+                    continue
+                chosen_symbol = sym
+                if tag_family_name and tag_type_name:
+                    break  # exact match found
+                if not tag_family_name and not tag_type_name:
+                    break  # first available wins
+
+            if chosen_symbol is None:
+                return routes.make_response(data={
+                    "error": "No matching wall-tag family symbol found.",
+                    "requested": {"family": tag_family_name, "type": tag_type_name},
+                    "available": available,
+                }, status=404)
+
+            # Collect walls visible in active view
+            walls = (DB.FilteredElementCollector(doc, active_view.Id)
+                     .OfCategory(DB.BuiltInCategory.OST_Walls)
+                     .WhereElementIsNotElementType())
+
+            placed = []
+            skipped_existing = 0
+            with DB.Transaction(doc, "MCP: Tag Walls") as t:
+                t.Start()
+                # Ensure the symbol is activated
+                if not chosen_symbol.IsActive:
+                    chosen_symbol.Activate()
+                    doc.Regenerate()
+                for wall in walls:
+                    loc = wall.Location
+                    if not isinstance(loc, DB.LocationCurve):
+                        continue
+                    curve = loc.Curve
+                    if curve is None:
+                        continue
+                    # Tag at the curve midpoint
+                    midpoint = curve.Evaluate(0.5, True)
+                    ref = DB.Reference(wall)
+                    tag = DB.IndependentTag.Create(
+                        doc, chosen_symbol.Id, active_view.Id, ref,
+                        with_leader, orientation, midpoint
+                    )
+                    placed.append({
+                        "wall_id": element_id_value(wall.Id),
+                        "tag_id": element_id_value(tag.Id),
+                    })
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "view": normalize_string(active_view.Name),
+                "tag_family": normalize_string(chosen_symbol.Family.Name) if hasattr(chosen_symbol, "Family") else None,
+                "tag_type": normalize_string(chosen_symbol.Name),
+                "tagged_count": len(placed),
+                "skipped_existing": skipped_existing,
+                "tags": placed[:50],  # cap response size
+                "total_returned": min(50, len(placed)),
+            })
+
+        except Exception as e:
+            logger.error("tag_walls failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Annotation routes registered successfully")

--- a/revit_mcp/dimensions.py
+++ b/revit_mcp/dimensions.py
@@ -1,0 +1,523 @@
+# -*- coding: UTF-8 -*-
+"""
+Dimensions Module for Revit MCP
+Create a linear Dimension between two points in a view, optionally locking the
+witness lines to geometric references on a set of elements (the typical
+"dimension between two parallel walls" case).
+
+Units: all inputs are in MILLIMETRES; converted internally to Revit's decimal
+feet via UnitUtils.
+
+Ported from Sparx mcp-servers-for-revit's CreateDimensionCommand (Apache-2.0
+licensed C# source at commandset/Services/AnnotationComponents/
+CreateDimensionEventHandler.cs) into our IronPython pyRevit Routes pattern.
+
+Notable differences from the C# source:
+- v1 ships single-dimension creation only; batch can be added later if a real
+  workflow demands it.
+- When `line_point` is supplied we actually USE it: the dim line is
+  reconstructed parallel to the start->end direction but anchored on the
+  supplied line point. The Sparx C# computes `linePoint` but never threads it
+  into `Doc.Create.NewDimension`, so its callers had to put start/end on the
+  desired dim line themselves.
+- When `line_point` is omitted, we default to a 1 ft (304.8 mm) perpendicular
+  offset from the midpoint of start/end (in the XY plane). Sparx instead used
+  start/end verbatim as the dim line, which often runs the dim line straight
+  through the elements being measured.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+FT_TO_MM = 304.8
+MM_TO_FT = 1.0 / 304.8
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _mm_to_feet(value_mm):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _xyz_from_mm(x_mm, y_mm, z_mm):
+    return DB.XYZ(_mm_to_feet(x_mm), _mm_to_feet(y_mm), _mm_to_feet(z_mm))
+
+
+def _resolve_view(doc, view_id):
+    """Return (view, source) or (None, reason)."""
+    if view_id is not None:
+        try:
+            vid = DB.ElementId(Int64(int(view_id)))
+        except Exception:
+            return None, "view_id_must_be_int"
+        el = doc.GetElement(vid)
+        if el is None or not isinstance(el, DB.View):
+            return None, "view_id_not_found"
+        return el, "explicit_view_id"
+    try:
+        uidoc = revit.uidoc
+    except Exception:
+        uidoc = None
+    if uidoc is None or uidoc.ActiveView is None:
+        return None, "no_active_view"
+    return uidoc.ActiveView, "active_view"
+
+
+def _safe_category_name(elem):
+    try:
+        cat = elem.Category
+        if cat is None:
+            return None
+        return normalize_string(cat.Name)
+    except Exception:
+        return None
+
+
+def _get_references_for_element(elem, view, dim_direction):
+    """
+    Walk an element's geometry in the given view, pick the planar face whose
+    normal is most aligned with `dim_direction` (in absolute value, so we
+    accept faces pointing either toward or away from the dim line — they're
+    the two parallel faces of a wall).
+
+    Faces whose normal is mostly vertical (|Z| > 0.9) are skipped — those are
+    the top/bottom of a wall and have no use in a plan dimension.
+
+    Returns a list (0 or 1 references) in order of priority:
+      1. Best-aligned planar face Reference.
+      2. Generic Reference(element) fallback if no usable face is found.
+    """
+    refs = []
+
+    opts = DB.Options()
+    opts.View = view
+    opts.ComputeReferences = True
+
+    try:
+        geom = elem.get_Geometry(opts)
+    except Exception:
+        geom = None
+
+    best_ref = None
+    best_alignment = -1.0
+
+    def _scan_solid(solid):
+        # Closure over best_ref / best_alignment via list to allow mutation in IronPython 2
+        # (nonlocal isn't available). Returns (best_ref, best_alignment) tuple.
+        local_best = best_ref_holder[0]
+        local_align = best_align_holder[0]
+        try:
+            face_iter = solid.Faces
+        except Exception:
+            return
+        for face in face_iter:
+            if not isinstance(face, DB.PlanarFace):
+                continue
+            try:
+                normal = face.FaceNormal
+            except Exception:
+                continue
+            if abs(normal.Z) > 0.9:
+                # Horizontal face — skip (top/bottom of wall is useless for plan dim)
+                continue
+            if dim_direction is not None:
+                try:
+                    alignment = abs(normal.DotProduct(dim_direction))
+                except Exception:
+                    continue
+                if alignment > local_align:
+                    local_align = alignment
+                    local_best = face.Reference
+            else:
+                # No direction info — first vertical face wins
+                if face.Reference is not None:
+                    refs.append(face.Reference)
+                    return
+        best_ref_holder[0] = local_best
+        best_align_holder[0] = local_align
+
+    best_ref_holder = [None]
+    best_align_holder = [-1.0]
+
+    if geom is not None:
+        for obj in geom:
+            if isinstance(obj, DB.Solid) and obj.Faces.Size > 0:
+                _scan_solid(obj)
+                if refs:  # early-exit fallback path
+                    return refs
+            elif isinstance(obj, DB.GeometryInstance):
+                try:
+                    sub_geom = obj.GetInstanceGeometry()
+                except Exception:
+                    sub_geom = None
+                if sub_geom is None:
+                    continue
+                for sub_obj in sub_geom:
+                    if isinstance(sub_obj, DB.Solid) and sub_obj.Faces.Size > 0:
+                        _scan_solid(sub_obj)
+                        if refs:
+                            return refs
+
+    best_ref = best_ref_holder[0]
+    if best_ref is not None:
+        refs.append(best_ref)
+        return refs
+
+    # Last-resort fallback: generic reference to the element itself.
+    try:
+        refs.append(DB.Reference(elem))
+    except Exception:
+        pass
+    return refs
+
+
+def _find_reference_at_point(doc, view, point, dim_direction, tolerance_ft=5.0):
+    """
+    Point-based fallback used when no element_ids are supplied. Finds the
+    closest element in the view to `point` (within `tolerance_ft` feet) and
+    delegates to _get_references_for_element to pick a face on it.
+    """
+    coll = DB.FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType()
+
+    closest_elem = None
+    min_dist = float("inf")
+
+    for elem in coll:
+        try:
+            loc = elem.Location
+        except Exception:
+            loc = None
+        if loc is None:
+            continue
+        elem_pt = None
+        try:
+            if isinstance(loc, DB.LocationPoint):
+                elem_pt = loc.Point
+            elif isinstance(loc, DB.LocationCurve):
+                try:
+                    proj = loc.Curve.Project(point)
+                except Exception:
+                    proj = None
+                if proj is not None:
+                    elem_pt = proj.XYZPoint
+        except Exception:
+            elem_pt = None
+        if elem_pt is None:
+            continue
+        try:
+            d = point.DistanceTo(elem_pt)
+        except Exception:
+            continue
+        if d < min_dist:
+            min_dist = d
+            closest_elem = elem
+
+    if closest_elem is None or min_dist > tolerance_ft:
+        return None, closest_elem, min_dist
+
+    refs = _get_references_for_element(closest_elem, view, dim_direction)
+    if not refs:
+        return None, closest_elem, min_dist
+    return refs[0], closest_elem, min_dist
+
+
+def _default_line_point(start, end, dim_direction):
+    """
+    Build the default dim line: perpendicular to dim_direction in XY, offset
+    1 ft (304.8 mm) from the midpoint of start/end. For purely vertical
+    dimensions where the XY projection is zero, fall back to +X as the
+    perpendicular direction.
+    """
+    dim_xy_x = dim_direction.X
+    dim_xy_y = dim_direction.Y
+    xy_len_sq = dim_xy_x * dim_xy_x + dim_xy_y * dim_xy_y
+    if xy_len_sq > 1e-12:
+        xy_len = xy_len_sq ** 0.5
+        # Rotate 90° CCW in XY plane: (x, y) -> (-y, x)
+        perp = DB.XYZ(-dim_xy_y / xy_len, dim_xy_x / xy_len, 0.0)
+    else:
+        perp = DB.XYZ(1.0, 0.0, 0.0)
+    offset_ft = _mm_to_feet(304.8)  # exactly 1 ft
+    midpoint = DB.XYZ(
+        (start.X + end.X) / 2.0,
+        (start.Y + end.Y) / 2.0,
+        (start.Z + end.Z) / 2.0,
+    )
+    return midpoint.Add(perp.Multiply(offset_ft))
+
+
+def register_dimensions_routes(api):
+    """Register dimension-creation routes."""
+
+    @api.route("/create_dimension/", methods=["POST"])
+    def create_dimension(doc, request):
+        """
+        Create a linear Dimension between two points (and optionally between
+        a list of elements) in the given view.
+
+        Expected payload (all coordinates in MILLIMETRES):
+        {
+            "start_x_mm":         0.0,         # required
+            "start_y_mm":         0.0,         # required
+            "start_z_mm":         0.0,         # required
+            "end_x_mm":           5000.0,      # required
+            "end_y_mm":           0.0,         # required
+            "end_z_mm":           0.0,         # required
+            "line_x_mm":          null,        # optional dim-line anchor
+            "line_y_mm":          null,
+            "line_z_mm":          null,
+            "element_ids":        [123, 456],  # optional, walls/elements to dim
+            "view_id":            null,        # optional, defaults to active view
+            "dimension_style_id": null         # optional DimensionType id
+        }
+
+        Returns status='success' with the new dimension's id and measured
+        value, OR a recoverable status like 'no_references_found' /
+        'fewer_than_2_references' when the geometric reference picker can't
+        find what to lock onto.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+
+            # ----- Required: start / end points -----
+            required = ("start_x_mm", "start_y_mm", "start_z_mm",
+                        "end_x_mm", "end_y_mm", "end_z_mm")
+            for k in required:
+                if k not in data or data[k] is None:
+                    return routes.make_response(data={
+                        "error": "Missing required field: {} (number, millimetres)".format(k)
+                    }, status=400)
+            try:
+                start = _xyz_from_mm(data["start_x_mm"], data["start_y_mm"], data["start_z_mm"])
+                end = _xyz_from_mm(data["end_x_mm"], data["end_y_mm"], data["end_z_mm"])
+            except (TypeError, ValueError) as ve:
+                return routes.make_response(data={
+                    "error": "start/end coordinates must be numbers: {}".format(ve)
+                }, status=400)
+
+            try:
+                separation_ft = start.DistanceTo(end)
+            except Exception:
+                separation_ft = 0.0
+            if separation_ft < 1e-9:
+                return routes.make_response(data={
+                    "error": "start and end points are identical; dimension direction undefined"
+                }, status=400)
+
+            dim_direction = (end.Subtract(start)).Normalize()
+
+            # ----- Optional: line point (anchors the dim line) -----
+            has_line_pt = (
+                data.get("line_x_mm") is not None
+                and data.get("line_y_mm") is not None
+                and data.get("line_z_mm") is not None
+            )
+            if has_line_pt:
+                try:
+                    line_anchor = _xyz_from_mm(data["line_x_mm"], data["line_y_mm"], data["line_z_mm"])
+                except (TypeError, ValueError) as ve:
+                    return routes.make_response(data={
+                        "error": "line point coordinates must be numbers: {}".format(ve)
+                    }, status=400)
+                line_anchor_source = "explicit"
+            else:
+                line_anchor = _default_line_point(start, end, dim_direction)
+                line_anchor_source = "default_1ft_perp_offset"
+
+            half_len = separation_ft / 2.0
+            dim_line_start = line_anchor.Subtract(dim_direction.Multiply(half_len))
+            dim_line_end = line_anchor.Add(dim_direction.Multiply(half_len))
+
+            # ----- Resolve view -----
+            view, view_source = _resolve_view(doc, data.get("view_id"))
+            if view is None:
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": view_source,
+                })
+
+            # ----- Resolve element_ids (optional) -----
+            element_ids_raw = data.get("element_ids") or []
+            if not isinstance(element_ids_raw, list):
+                return routes.make_response(data={
+                    "error": "element_ids must be a list of integers"
+                }, status=400)
+
+            elements = []
+            invalid_ids = []
+            for eid in element_ids_raw:
+                try:
+                    el = doc.GetElement(DB.ElementId(Int64(int(eid))))
+                except Exception:
+                    el = None
+                if el is None:
+                    invalid_ids.append(eid)
+                else:
+                    elements.append(el)
+
+            # ----- Build references -----
+            ref_array = DB.ReferenceArray()
+            ref_diag = []
+            picker_path = None
+
+            if elements:
+                picker_path = "element_ids"
+                for elem in elements:
+                    picked = _get_references_for_element(elem, view, dim_direction)
+                    for r in picked:
+                        ref_array.Append(r)
+                        ref_diag.append({
+                            "element_id": element_id_value(elem.Id),
+                            "category": _safe_category_name(elem),
+                            "source": "element_geometry",
+                        })
+            else:
+                picker_path = "point_proximity"
+                start_ref, start_elem, start_dist = _find_reference_at_point(doc, view, start, dim_direction)
+                end_ref, end_elem, end_dist = _find_reference_at_point(doc, view, end, dim_direction)
+                if start_ref is not None:
+                    ref_array.Append(start_ref)
+                    ref_diag.append({
+                        "source": "start_point_proximity",
+                        "element_id": element_id_value(start_elem.Id) if start_elem is not None else None,
+                        "distance_ft": round(start_dist, 4) if start_dist != float("inf") else None,
+                    })
+                if end_ref is not None:
+                    ref_array.Append(end_ref)
+                    ref_diag.append({
+                        "source": "end_point_proximity",
+                        "element_id": element_id_value(end_elem.Id) if end_elem is not None else None,
+                        "distance_ft": round(end_dist, 4) if end_dist != float("inf") else None,
+                    })
+
+            if ref_array.Size < 2:
+                return routes.make_response(data={
+                    "status": "no_references_found" if ref_array.Size == 0 else "fewer_than_2_references",
+                    "error": "Could not gather >= 2 geometric references to dimension "
+                             "(found {}). Provide element_ids of two parallel walls/elements, "
+                             "or make sure start/end points lie within 5 ft of dimensionable "
+                             "elements visible in the view.".format(ref_array.Size),
+                    "references_collected": ref_array.Size,
+                    "references": ref_diag,
+                    "invalid_element_ids": invalid_ids,
+                    "picker_path": picker_path,
+                    "view_name": normalize_string(view.Name),
+                    "view_id": element_id_value(view.Id),
+                })
+
+            # ----- Create the dimension in one transaction -----
+            dimension = None
+            with DB.Transaction(doc, "MCP: Create Dimension") as t:
+                t.Start()
+                try:
+                    dim_line = DB.Line.CreateBound(dim_line_start, dim_line_end)
+                except Exception as line_err:
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "invalid_dim_line",
+                        "error": "Failed to construct dim line: {}".format(line_err),
+                    })
+                try:
+                    dimension = doc.Create.NewDimension(view, dim_line, ref_array)
+                except Exception as create_err:
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "create_failed",
+                        "error": str(create_err),
+                        "references_collected": ref_array.Size,
+                        "references": ref_diag,
+                        "picker_path": picker_path,
+                        "view_name": normalize_string(view.Name),
+                        "view_id": element_id_value(view.Id),
+                    })
+
+                if dimension is None:
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "create_failed",
+                        "error": "Revit returned None from NewDimension (references likely don't lie on the dim line)",
+                        "references_collected": ref_array.Size,
+                        "references": ref_diag,
+                        "picker_path": picker_path,
+                    })
+
+                # Optional dimension style
+                style_id = data.get("dimension_style_id")
+                applied_style_id = None
+                applied_style_name = None
+                if style_id is not None:
+                    try:
+                        style_id_int = int(style_id)
+                    except (TypeError, ValueError):
+                        style_id_int = -1
+                    if style_id_int > 0:
+                        try:
+                            dtype = doc.GetElement(DB.ElementId(Int64(style_id_int)))
+                            if isinstance(dtype, DB.DimensionType):
+                                dimension.DimensionType = dtype
+                                applied_style_id = element_id_value(dtype.Id)
+                                try:
+                                    applied_style_name = normalize_string(dtype.Name)
+                                except Exception:
+                                    applied_style_name = None
+                        except Exception:
+                            pass
+
+                t.Commit()
+
+            # ----- Read the measured value -----
+            value_ft = None
+            try:
+                v = dimension.Value
+                if v is not None:
+                    value_ft = float(v)
+            except Exception:
+                value_ft = None
+            value_mm = (value_ft * FT_TO_MM) if value_ft is not None else None
+
+            return routes.make_response(data={
+                "status": "success",
+                "dimension": {
+                    "id": element_id_value(dimension.Id),
+                    "unique_id": dimension.UniqueId,
+                    "references_count": ref_array.Size,
+                    "value_mm": round(value_mm, 3) if value_mm is not None else None,
+                    "value_ft": round(value_ft, 4) if value_ft is not None else None,
+                    "view_name": normalize_string(view.Name),
+                    "view_id": element_id_value(view.Id),
+                    "dimension_style_id": applied_style_id,
+                    "dimension_style_name": applied_style_name,
+                },
+                "references": ref_diag,
+                "picker_path": picker_path,
+                "view_source": view_source,
+                "line_anchor_source": line_anchor_source,
+                "invalid_element_ids": invalid_ids,
+            })
+
+        except Exception as e:
+            logger.error("create_dimension failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Dimensions routes registered successfully")

--- a/revit_mcp/element_creation.py
+++ b/revit_mcp/element_creation.py
@@ -8,7 +8,7 @@ Internally converted to Revit's decimal-feet via UnitUtils.
 """
 
 from pyrevit import routes, revit, DB
-from utils import normalize_string, element_id_value
+from utils import normalize_string, element_id_value, get_element_name
 from System import Int64
 import json
 import traceback
@@ -40,16 +40,21 @@ def _find_level_by_name(doc, level_name):
     """Locate a Level by exact name. Returns None if not found."""
     levels = DB.FilteredElementCollector(doc).OfClass(DB.Level)
     for lvl in levels:
-        if lvl.Name == level_name:
+        if get_element_name(lvl) == level_name:
             return lvl
     return None
 
 
 def _find_type_by_name(doc, type_class, type_name):
-    """Locate an ElementType (WallType / FloorType / CeilingType) by exact name."""
+    """Locate an ElementType (WallType / FloorType / CeilingType) by exact name.
+
+    Revit 2026 IronPython: ElementType subclasses raise AttributeError on direct
+    `.Name` access via the `Element` base ambiguity. Use the descriptor accessor
+    via `get_element_name()` (see utils.py).
+    """
     collector = DB.FilteredElementCollector(doc).OfClass(type_class)
     for t in collector:
-        if t.Name == type_name:
+        if get_element_name(t) == type_name:
             return t
     return None
 

--- a/revit_mcp/element_creation.py
+++ b/revit_mcp/element_creation.py
@@ -9,6 +9,7 @@ Internally converted to Revit's decimal-feet via UnitUtils.
 
 from pyrevit import routes, revit, DB
 from utils import normalize_string, element_id_value
+from System import Int64
 import json
 import traceback
 import logging
@@ -81,7 +82,7 @@ def _set_instance_parameters(element, properties):
                 # Caller is responsible for unit conversion; accept raw float
                 p.Set(float(value))
             elif st == DB.StorageType.ElementId:
-                p.Set(DB.ElementId(int(value)))
+                p.Set(DB.ElementId(Int64(int(value))))
             written.append(name)
         except Exception as pe:
             logger.warning("Could not set parameter {}: {}".format(name, str(pe)))

--- a/revit_mcp/element_creation.py
+++ b/revit_mcp/element_creation.py
@@ -1,0 +1,272 @@
+# -*- coding: UTF-8 -*-
+"""
+Element Creation Module for Revit MCP
+Line-based (Wall) and surface-based (Floor / Ceiling) creation endpoints.
+
+Units: input coordinates and dimensions are expected in MILLIMETRES.
+Internally converted to Revit's decimal-feet via UnitUtils.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+def _mm_to_feet(value_mm):
+    """Convert a length in millimetres to Revit's internal feet."""
+    try:
+        # Revit 2021+
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        # Revit <2021 fallback
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _xyz_mm(point_dict):
+    """Build a DB.XYZ in internal feet from a {x,y,z} dict expressed in mm."""
+    return DB.XYZ(_mm_to_feet(point_dict["x"]), _mm_to_feet(point_dict["y"]), _mm_to_feet(point_dict["z"]))
+
+
+def _find_level_by_name(doc, level_name):
+    """Locate a Level by exact name. Returns None if not found."""
+    levels = DB.FilteredElementCollector(doc).OfClass(DB.Level)
+    for lvl in levels:
+        if lvl.Name == level_name:
+            return lvl
+    return None
+
+
+def _find_type_by_name(doc, type_class, type_name):
+    """Locate an ElementType (WallType / FloorType / CeilingType) by exact name."""
+    collector = DB.FilteredElementCollector(doc).OfClass(type_class)
+    for t in collector:
+        if t.Name == type_name:
+            return t
+    return None
+
+
+def _parse_json_request(request):
+    """Pull the JSON payload from a pyRevit route request. Returns dict or raises."""
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _set_instance_parameters(element, properties):
+    """Apply a dict of {param_name: value} to an element, best-effort."""
+    if not properties:
+        return []
+    written = []
+    for name, value in properties.items():
+        try:
+            p = element.LookupParameter(name)
+            if p is None or p.IsReadOnly:
+                continue
+            st = p.StorageType
+            if st == DB.StorageType.String:
+                p.Set(unicode(value) if isinstance(value, str) else value)
+            elif st == DB.StorageType.Integer:
+                p.Set(int(value))
+            elif st == DB.StorageType.Double:
+                # Caller is responsible for unit conversion; accept raw float
+                p.Set(float(value))
+            elif st == DB.StorageType.ElementId:
+                p.Set(DB.ElementId(int(value)))
+            written.append(name)
+        except Exception as pe:
+            logger.warning("Could not set parameter {}: {}".format(name, str(pe)))
+    return written
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Routes
+# ─────────────────────────────────────────────────────────────────────────
+
+def register_element_creation_routes(api):
+    """Register element-creation routes (line + surface based)."""
+
+    @api.route("/create_line_based_element/", methods=["POST"])
+    def create_line_based_element(doc, request):
+        """
+        Create a line-based element. Currently supports walls only.
+
+        Expected payload:
+        {
+            "category": "wall",
+            "type_name": "Generic - 200mm",
+            "level_name": "Level 1",
+            "start": {"x": 0.0, "y": 0.0, "z": 0.0},   // mm, relative to project origin
+            "end":   {"x": 5000.0, "y": 0.0, "z": 0.0},
+            "height_mm": 3000.0,
+            "structural": false,                         // optional
+            "properties": { "Comments": "via MCP" }      // optional, instance params
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            category = (data.get("category") or "wall").lower()
+            if category != "wall":
+                return routes.make_response(data={
+                    "error": "Only category='wall' is implemented. Beams/pipes require Structural/MEP family discipline and are not yet wired."
+                }, status=400)
+
+            type_name = data.get("type_name")
+            level_name = data.get("level_name")
+            start = data.get("start")
+            end = data.get("end")
+            height_mm = data.get("height_mm")
+            structural = bool(data.get("structural", False))
+            properties = data.get("properties", {})
+
+            for field, val in (("type_name", type_name), ("level_name", level_name),
+                               ("start", start), ("end", end), ("height_mm", height_mm)):
+                if val in (None, ""):
+                    return routes.make_response(data={"error": "Missing required field: {}".format(field)}, status=400)
+
+            wall_type = _find_type_by_name(doc, DB.WallType, type_name)
+            if wall_type is None:
+                return routes.make_response(data={"error": "WallType not found: {}".format(type_name)}, status=404)
+
+            level = _find_level_by_name(doc, level_name)
+            if level is None:
+                return routes.make_response(data={"error": "Level not found: {}".format(level_name)}, status=404)
+
+            start_xyz = _xyz_mm(start)
+            end_xyz = _xyz_mm(end)
+            if start_xyz.DistanceTo(end_xyz) < 1e-6:
+                return routes.make_response(data={"error": "Wall start and end coincide"}, status=400)
+
+            with DB.Transaction(doc, "MCP: Create Wall") as t:
+                t.Start()
+                line = DB.Line.CreateBound(start_xyz, end_xyz)
+                wall = DB.Wall.Create(
+                    doc, line, wall_type.Id, level.Id,
+                    _mm_to_feet(height_mm), 0.0, False, structural
+                )
+                written_params = _set_instance_parameters(wall, properties)
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "element_id": element_id_value(wall.Id),
+                "wall_type": type_name,
+                "level": level_name,
+                "length_mm": float(start_xyz.DistanceTo(end_xyz)) * 304.8,
+                "height_mm": float(height_mm),
+                "structural": structural,
+                "parameters_written": written_params,
+            })
+
+        except Exception as e:
+            logger.error("create_line_based_element failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_surface_based_element/", methods=["POST"])
+    def create_surface_based_element(doc, request):
+        """
+        Create a surface-based element (floor or ceiling) from a closed boundary.
+
+        Expected payload:
+        {
+            "category": "floor",                          // or "ceiling"
+            "type_name": "Generic 150mm",
+            "level_name": "Level 1",
+            "boundary": [                                  // mm, closed loop (first == last not required; will be closed automatically)
+                {"x": 0,    "y": 0,    "z": 0},
+                {"x": 5000, "y": 0,    "z": 0},
+                {"x": 5000, "y": 5000, "z": 0},
+                {"x": 0,    "y": 5000, "z": 0}
+            ],
+            "properties": { "Comments": "via MCP" }       // optional
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            category = (data.get("category") or "").lower()
+            if category not in ("floor", "ceiling"):
+                return routes.make_response(data={"error": "category must be 'floor' or 'ceiling'"}, status=400)
+
+            type_name = data.get("type_name")
+            level_name = data.get("level_name")
+            boundary = data.get("boundary")
+            properties = data.get("properties", {})
+
+            for field, val in (("type_name", type_name), ("level_name", level_name), ("boundary", boundary)):
+                if val in (None, ""):
+                    return routes.make_response(data={"error": "Missing required field: {}".format(field)}, status=400)
+            if not isinstance(boundary, list) or len(boundary) < 3:
+                return routes.make_response(data={"error": "boundary must be a list of >= 3 points"}, status=400)
+
+            level = _find_level_by_name(doc, level_name)
+            if level is None:
+                return routes.make_response(data={"error": "Level not found: {}".format(level_name)}, status=404)
+
+            # Build CurveLoop from boundary, closing it explicitly if not already closed
+            pts = [_xyz_mm(p) for p in boundary]
+            if pts[0].DistanceTo(pts[-1]) > 1e-6:
+                pts.append(pts[0])
+            loop = DB.CurveLoop()
+            for i in range(len(pts) - 1):
+                if pts[i].DistanceTo(pts[i + 1]) < 1e-6:
+                    continue
+                loop.Append(DB.Line.CreateBound(pts[i], pts[i + 1]))
+
+            if category == "floor":
+                floor_type = _find_type_by_name(doc, DB.FloorType, type_name)
+                if floor_type is None:
+                    return routes.make_response(data={"error": "FloorType not found: {}".format(type_name)}, status=404)
+                with DB.Transaction(doc, "MCP: Create Floor") as t:
+                    t.Start()
+                    # Revit 2022+ requires a List[CurveLoop]; build via .NET generics
+                    from System.Collections.Generic import List as NetList
+                    loop_list = NetList[DB.CurveLoop]()
+                    loop_list.Add(loop)
+                    floor = DB.Floor.Create(doc, loop_list, floor_type.Id, level.Id)
+                    written_params = _set_instance_parameters(floor, properties)
+                    t.Commit()
+                el_id = floor.Id
+            else:  # ceiling
+                ceiling_type = _find_type_by_name(doc, DB.CeilingType, type_name)
+                if ceiling_type is None:
+                    return routes.make_response(data={"error": "CeilingType not found: {}".format(type_name)}, status=404)
+                with DB.Transaction(doc, "MCP: Create Ceiling") as t:
+                    t.Start()
+                    from System.Collections.Generic import List as NetList
+                    loop_list = NetList[DB.CurveLoop]()
+                    loop_list.Add(loop)
+                    ceiling = DB.Ceiling.Create(doc, loop_list, ceiling_type.Id, level.Id)
+                    written_params = _set_instance_parameters(ceiling, properties)
+                    t.Commit()
+                el_id = ceiling.Id
+
+            return routes.make_response(data={
+                "status": "success",
+                "element_id": element_id_value(el_id),
+                "category": category,
+                "type": type_name,
+                "level": level_name,
+                "vertex_count": len(boundary),
+                "parameters_written": written_params,
+            })
+
+        except Exception as e:
+            logger.error("create_surface_based_element failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Element-creation routes registered successfully")

--- a/revit_mcp/element_filter.py
+++ b/revit_mcp/element_filter.py
@@ -1,0 +1,923 @@
+# -*- coding: UTF-8 -*-
+"""
+Element Filter Module for Revit MCP
+
+A structured multi-criteria element filter that returns rich per-element
+information dispatched on the element's kind. Useful for queries like:
+
+    - "Find every wall named 'Generic - 200mm'"
+    - "Get all doors visible in the current view"
+    - "List rooms on Level 2 with their area / volume / perimeter"
+    - "Find all family instances inside this bounding box"
+
+Filters (any combination, AND'd together):
+
+    filter_category               BuiltInCategory name, e.g. "OST_Walls"
+    filter_element_type           .NET class name under Autodesk.Revit.DB,
+                                  e.g. "Wall", "FamilyInstance"
+    filter_family_symbol_id       FamilySymbol ElementId (instances only)
+    include_types                 include ElementType subclasses
+    include_instances             include element instances (default true)
+    filter_visible_in_current_view restrict instances to the active view
+    view_id                       restrict instances to this specific view
+                                  (takes precedence over the active view)
+    bounding_box_min / _max       3D filter, both in mm, [x, y, z]
+    name_contains                 case-insensitive substring on Element.Name
+    max_elements                  cap on result size (0 = unlimited)
+
+Per-element info shape depends on the element kind:
+
+    HasMaterialQuantities (Wall, Floor, Column, Door, Window, ...)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, type_id, room_id, level, bounding_box,
+        parameters (thickness_mm, bbox_height_mm)
+
+    ElementType (WallType, FloorType, FamilySymbol, ...)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, parameters (Length/Area/Volume/Angle params, with
+        thickness_mm appended when applicable)
+
+    Positioning (Level, Grid)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box, level, plus:
+            Level -> elevation_mm
+            Grid  -> grid_line (start_mm, end_mm)
+
+    Spatial (Room, Area)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box, level, number, plus:
+            Room -> volume_m3
+            Both -> area_m2, perimeter_mm (when ROOM_AREA / ROOM_PERIMETER
+                                            are populated)
+
+    View
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box, view_type, scale, is_template,
+        detail_level, associated_level (ViewPlan only), is_open, is_active
+
+    Annotation (TextNote, Dimension, IndependentTag, SpotDimension,
+                AnnotationSymbol when present)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box, owner_view, plus:
+            TextNote   -> text_content, position_mm
+            Dimension  -> dimension_value, position_mm
+            others     -> position_mm (from LocationPoint)
+
+    Group / RevitLinkInstance
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box, plus:
+            Group              -> member_count, group_type
+            RevitLinkInstance  -> link_path, link_status, position_mm
+
+    Fallback (anything else)
+        id, unique_id, name, family_name, category, built_in_category,
+        element_class, bounding_box
+
+Ported from Sparx mcp-servers-for-revit's AIElementFilterCommand
+(Apache-2.0 licensed C# source at commandset/Services/
+AIElementFilterEventHandler.cs) into our IronPython pyRevit Routes pattern.
+
+Differences from the C# source:
+- Length / area / volume outputs use UnitUtils.ConvertFromInternalUnits to
+  produce honest mm / m2 / m3 values (Sparx multiplied by 304.8^N which
+  conflated "mm in project units" with raw scaled feet).
+- Adds explicit view_id input on top of filter_visible_in_current_view —
+  useful when the caller knows the target view (e.g. from list_revit_views)
+  but isn't asking the user to focus it first.
+- Adds name_contains substring filter — Sparx had no name filter.
+- Returns applied_filters diagnostic list so the caller can see exactly
+  which filters got applied (matches Sparx's Trace.WriteLine output but
+  exposed in the response).
+- Returns matched_count separately from returned_count so the caller can
+  see when the cap was hit (Sparx mixed "got N elements" into the message
+  string).
+
+Read-only — no transactions.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64, Type
+from System.Collections.Generic import List as NetList
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ELEMENTS = 100
+
+# Cached BuiltInCategory int -> name map. Built lazily once per pyRevit load.
+_BIC_NAME_CACHE = None
+
+
+def _bic_name_for(cat_id_v):
+    """Return 'OST_Walls' style name for a Category.Id value, or None."""
+    global _BIC_NAME_CACHE
+    if _BIC_NAME_CACHE is None:
+        cache = {}
+        for name in dir(DB.BuiltInCategory):
+            if name.startswith("OST_"):
+                try:
+                    v = getattr(DB.BuiltInCategory, name)
+                    cache[int(v)] = name
+                except Exception:
+                    continue
+        _BIC_NAME_CACHE = cache
+    return _BIC_NAME_CACHE.get(int(cat_id_v))
+
+
+# ---------- JSON / unit helpers ----------
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _mm_to_feet(v):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(v), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(v), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _ft_to_mm(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _ft2_to_m2(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.SquareMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_SQUARE_METERS)
+
+
+def _ft3_to_m3(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.CubicMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_CUBIC_METERS)
+
+
+def _xyz_to_mm(p):
+    if p is None:
+        return None
+    return {
+        "x_mm": round(_ft_to_mm(p.X), 3),
+        "y_mm": round(_ft_to_mm(p.Y), 3),
+        "z_mm": round(_ft_to_mm(p.Z), 3),
+    }
+
+
+def _get_bbox_info(elem):
+    try:
+        bb = elem.get_BoundingBox(None)
+        if bb is None:
+            return None
+        return {"min": _xyz_to_mm(bb.Min), "max": _xyz_to_mm(bb.Max)}
+    except Exception:
+        return None
+
+
+def _safe_name(elem):
+    try:
+        return normalize_string(get_element_name(elem))
+    except Exception:
+        return None
+
+
+def _param_value_string(elem, bip):
+    try:
+        p = elem.get_Parameter(bip)
+        if p and p.HasValue:
+            return normalize_string(p.AsValueString())
+    except Exception:
+        pass
+    return None
+
+
+def _level_for_element(doc, elem):
+    """Resolve the level for an element via the same hierarchy Sparx uses."""
+    level = None
+    try:
+        if isinstance(elem, DB.Wall):
+            level = doc.GetElement(elem.LevelId)
+        elif isinstance(elem, DB.Floor):
+            p = elem.get_Parameter(DB.BuiltInParameter.LEVEL_PARAM)
+            if p and p.HasValue:
+                level = doc.GetElement(p.AsElementId())
+        elif isinstance(elem, DB.FamilyInstance):
+            p = elem.get_Parameter(DB.BuiltInParameter.FAMILY_LEVEL_PARAM)
+            if p and p.HasValue:
+                level = doc.GetElement(p.AsElementId())
+            if level is None:
+                p = elem.get_Parameter(DB.BuiltInParameter.SCHEDULE_LEVEL_PARAM)
+                if p and p.HasValue:
+                    level = doc.GetElement(p.AsElementId())
+        else:
+            p = elem.get_Parameter(DB.BuiltInParameter.INSTANCE_REFERENCE_LEVEL_PARAM)
+            if p and p.HasValue:
+                level = doc.GetElement(p.AsElementId())
+    except Exception:
+        level = None
+    if level is None or not isinstance(level, DB.Level):
+        return None
+    return {
+        "id": element_id_value(level.Id),
+        "name": normalize_string(level.Name),
+        "elevation_mm": round(_ft_to_mm(level.Elevation), 3),
+    }
+
+
+# ---------- Filter parsing ----------
+
+def _parse_category(cat_name):
+    """Return (BuiltInCategory member, None) or (None, error_message)."""
+    if not cat_name:
+        return None, None
+    if not isinstance(cat_name, (str, unicode)):
+        return None, "filter_category must be a string"
+    cname = cat_name if cat_name.startswith("OST_") else "OST_" + cat_name
+    member = getattr(DB.BuiltInCategory, cname, None)
+    if member is None:
+        return None, "unknown BuiltInCategory: {}".format(cat_name)
+    return member, None
+
+
+def _resolve_element_class(class_name):
+    """Resolve a .NET Type for the given Revit DB class name. Returns (Type, error)."""
+    if not class_name:
+        return None, None
+    if not isinstance(class_name, (str, unicode)):
+        return None, "filter_element_type must be a string"
+    bare = class_name
+    if "." in bare:
+        bare = bare.rsplit(".", 1)[-1]
+    # First try getattr on pyRevit's DB module (covers Autodesk.Revit.DB.*)
+    candidate = getattr(DB, bare, None)
+    if candidate is not None:
+        try:
+            # Confirm we got a .NET type rather than a Python sub-module
+            if hasattr(candidate, "Assembly"):
+                return candidate, None
+        except Exception:
+            pass
+    # Then try System.Type.GetType with the common assembly hints
+    candidates = [
+        class_name,
+        "Autodesk.Revit.DB.{}, RevitAPI".format(bare),
+        "{}, RevitAPI".format(class_name),
+    ]
+    for tn in candidates:
+        try:
+            t = Type.GetType(tn)
+            if t is not None:
+                return t, None
+        except Exception:
+            continue
+    return None, "could not resolve .NET type '{}' under Autodesk.Revit.DB".format(class_name)
+
+
+def _resolve_view(doc, view_id):
+    """(view, source) or ('ERROR', reason). view_id=None means no view filter."""
+    if view_id is None:
+        return None, "no_view_filter"
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return "ERROR", "view_id_must_be_int"
+    el = doc.GetElement(vid)
+    if el is None or not isinstance(el, DB.View):
+        return "ERROR", "view_id_not_found"
+    return el, "explicit_view_id"
+
+
+# ---------- Validation ----------
+
+def _validate(data, settings):
+    """Mutates `settings` in-place with resolved filter values. Returns (ok, error)."""
+    include_types = bool(data.get("include_types", False))
+    include_instances = bool(data.get("include_instances", True))
+    if not include_types and not include_instances:
+        return False, "include_types and include_instances cannot both be false"
+    settings["include_types"] = include_types
+    settings["include_instances"] = include_instances
+
+    cat_raw = data.get("filter_category")
+    elem_type_raw = data.get("filter_element_type")
+    family_symbol_id = data.get("filter_family_symbol_id")
+    if family_symbol_id in (None, ""):
+        family_symbol_id = -1
+    try:
+        family_symbol_id = int(family_symbol_id)
+    except Exception:
+        return False, "filter_family_symbol_id must be an integer"
+
+    settings["filter_category"] = cat_raw
+    settings["filter_element_type"] = elem_type_raw
+    settings["filter_family_symbol_id"] = family_symbol_id
+    settings["filter_visible_in_current_view"] = bool(data.get("filter_visible_in_current_view", False))
+    settings["name_contains"] = data.get("name_contains") or None
+
+    bb_min = data.get("bounding_box_min")
+    bb_max = data.get("bounding_box_max")
+    if (bb_min is None) != (bb_max is None):
+        return False, "bounding_box_min and bounding_box_max must both be set or both omitted"
+    if bb_min is not None:
+        for arr, key in [(bb_min, "bounding_box_min"), (bb_max, "bounding_box_max")]:
+            if not (isinstance(arr, list) and len(arr) == 3):
+                return False, "{} must be a 3-element list [x_mm, y_mm, z_mm]".format(key)
+            for v in arr:
+                if not isinstance(v, (int, float)):
+                    return False, "{} values must be numbers".format(key)
+        if bb_min[0] > bb_max[0] or bb_min[1] > bb_max[1] or bb_min[2] > bb_max[2]:
+            return False, "bounding_box_min must be <= bounding_box_max on every axis"
+    settings["bounding_box_min"] = bb_min
+    settings["bounding_box_max"] = bb_max
+
+    has_filter = (
+        bool(cat_raw) or bool(elem_type_raw) or family_symbol_id > 0
+        or bb_min is not None or settings["name_contains"] is not None
+    )
+    if not has_filter:
+        return False, ("at least one filter must be specified: filter_category, "
+                       "filter_element_type, filter_family_symbol_id, "
+                       "bounding_box_min/max, or name_contains")
+
+    if include_types and not include_instances:
+        invalid = []
+        if family_symbol_id > 0:
+            invalid.append("filter_family_symbol_id")
+        if settings["filter_visible_in_current_view"]:
+            invalid.append("filter_visible_in_current_view")
+        if settings.get("_view_obj") is not None:
+            invalid.append("view_id")
+        if invalid:
+            return False, ("when only element types are included, these filters do not apply: "
+                           + ", ".join(invalid))
+
+    if cat_raw:
+        enum_val, err = _parse_category(cat_raw)
+        if err:
+            return False, err
+        settings["_category_enum"] = enum_val
+    else:
+        settings["_category_enum"] = None
+
+    if elem_type_raw:
+        t, err = _resolve_element_class(elem_type_raw)
+        if err:
+            return False, err
+        settings["_class_type"] = t
+    else:
+        settings["_class_type"] = None
+
+    return True, None
+
+
+# ---------- Collection ----------
+
+def _collect(doc, is_element_type, settings, applied_filters):
+    """Mirror of Sparx GetElementsByKind. Returns list[Element]."""
+    explicit_view = settings.get("_view_obj")
+    use_active = bool(settings.get("filter_visible_in_current_view"))
+
+    if not is_element_type and explicit_view is not None:
+        collector = DB.FilteredElementCollector(doc, explicit_view.Id)
+        applied_filters.append("view_id={}".format(element_id_value(explicit_view.Id)))
+    elif not is_element_type and use_active and doc.ActiveView is not None:
+        collector = DB.FilteredElementCollector(doc, doc.ActiveView.Id)
+        applied_filters.append("current_view_visible")
+    else:
+        collector = DB.FilteredElementCollector(doc)
+
+    if is_element_type:
+        collector = collector.WhereElementIsElementType()
+        applied_filters.append("element_types_only")
+    else:
+        collector = collector.WhereElementIsNotElementType()
+        applied_filters.append("instances_only")
+
+    filters = []
+    bic = settings.get("_category_enum")
+    if bic is not None:
+        filters.append(DB.ElementCategoryFilter(bic))
+        applied_filters.append("category={}".format(settings.get("filter_category")))
+
+    klass = settings.get("_class_type")
+    if klass is not None:
+        try:
+            filters.append(DB.ElementClassFilter(klass))
+            applied_filters.append("class={}".format(klass.Name))
+        except Exception as ex:
+            logger.warning("ElementClassFilter failed for %s: %s", getattr(klass, "Name", "?"), ex)
+            applied_filters.append("class_filter_failed")
+
+    fs_id = settings.get("filter_family_symbol_id")
+    if not is_element_type and fs_id and fs_id > 0:
+        try:
+            sid = DB.ElementId(Int64(int(fs_id)))
+            symbol_el = doc.GetElement(sid)
+            if symbol_el is not None and isinstance(symbol_el, DB.FamilySymbol):
+                filters.append(DB.FamilyInstanceFilter(doc, sid))
+                applied_filters.append("family_symbol_id={}".format(fs_id))
+            else:
+                applied_filters.append("family_symbol_id={}_invalid".format(fs_id))
+        except Exception as ex:
+            logger.warning("FamilyInstanceFilter failed: %s", ex)
+            applied_filters.append("family_symbol_id_filter_failed")
+
+    bb_min = settings.get("bounding_box_min")
+    bb_max = settings.get("bounding_box_max")
+    if bb_min is not None and bb_max is not None:
+        min_xyz = DB.XYZ(_mm_to_feet(bb_min[0]), _mm_to_feet(bb_min[1]), _mm_to_feet(bb_min[2]))
+        max_xyz = DB.XYZ(_mm_to_feet(bb_max[0]), _mm_to_feet(bb_max[1]), _mm_to_feet(bb_max[2]))
+        outline = DB.Outline(min_xyz, max_xyz)
+        filters.append(DB.BoundingBoxIntersectsFilter(outline))
+        applied_filters.append("bbox_intersects")
+
+    if filters:
+        if len(filters) == 1:
+            collector = collector.WherePasses(filters[0])
+        else:
+            net_filters = NetList[DB.ElementFilter]()
+            for f in filters:
+                net_filters.Add(f)
+            collector = collector.WherePasses(DB.LogicalAndFilter(net_filters))
+
+    return list(collector.ToElements())
+
+
+def _post_filter_name(elements, name_contains):
+    if not name_contains:
+        return elements
+    nc = name_contains.lower()
+    out = []
+    for el in elements:
+        n = _safe_name(el)
+        if n and nc in n.lower():
+            out.append(el)
+    return out
+
+
+# ---------- Info builders ----------
+
+def _common_header(elem):
+    cat = None
+    try:
+        cat = elem.Category
+    except Exception:
+        cat = None
+    cat_name = None
+    bic = None
+    if cat is not None:
+        try:
+            cat_name = normalize_string(cat.Name)
+        except Exception:
+            cat_name = None
+        try:
+            bic = _bic_name_for(element_id_value(cat.Id))
+        except Exception:
+            bic = None
+    return {
+        "id": element_id_value(elem.Id),
+        "unique_id": elem.UniqueId,
+        "name": _safe_name(elem),
+        "family_name": _param_value_string(elem, DB.BuiltInParameter.ELEM_FAMILY_PARAM),
+        "category": cat_name,
+        "built_in_category": bic,
+        "element_class": type(elem).__name__,
+    }
+
+
+def _thickness_mm_from_type(elem_type):
+    """Return thickness in mm for system-family type elements (or None)."""
+    if elem_type is None:
+        return None
+    try:
+        param = None
+        if isinstance(elem_type, DB.WallType):
+            param = elem_type.get_Parameter(DB.BuiltInParameter.WALL_ATTR_WIDTH_PARAM)
+        elif isinstance(elem_type, DB.FloorType):
+            param = elem_type.get_Parameter(DB.BuiltInParameter.FLOOR_ATTR_THICKNESS_PARAM)
+        elif isinstance(elem_type, DB.CeilingType):
+            param = elem_type.get_Parameter(DB.BuiltInParameter.CEILING_THICKNESS)
+        elif isinstance(elem_type, DB.FamilySymbol):
+            cat = elem_type.Category
+            if cat is not None:
+                cv = element_id_value(cat.Id)
+                doors_id = int(DB.BuiltInCategory.OST_Doors)
+                windows_id = int(DB.BuiltInCategory.OST_Windows)
+                if cv in (doors_id, windows_id):
+                    param = elem_type.get_Parameter(DB.BuiltInParameter.FAMILY_THICKNESS_PARAM)
+        if param is not None and param.HasValue:
+            return _ft_to_mm(param.AsDouble())
+    except Exception:
+        pass
+    return None
+
+
+def _is_dimension_parameter(param):
+    """True iff param represents a Length/Area/Volume/Angle quantity."""
+    try:
+        d = param.Definition
+        if hasattr(d, "GetDataType"):
+            try:
+                dt = d.GetDataType()
+                for spec in ("Length", "Angle", "Area", "Volume"):
+                    s = getattr(DB.SpecTypeId, spec, None)
+                    if s is not None and dt.Equals(s):
+                        return True
+                return False
+            except Exception:
+                pass
+        if hasattr(d, "ParameterType"):
+            try:
+                pt = d.ParameterType
+                pt_enum = getattr(DB, "ParameterType", None)
+                if pt_enum is None:
+                    return False
+                return pt in (pt_enum.Length, pt_enum.Angle, pt_enum.Area, pt_enum.Volume)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return False
+
+
+def _build_instance_info(doc, elem):
+    info = _common_header(elem)
+    info["type_id"] = element_id_value(elem.GetTypeId())
+    if isinstance(elem, DB.FamilyInstance):
+        try:
+            room = elem.Room
+            info["room_id"] = element_id_value(room.Id) if room is not None else -1
+        except Exception:
+            info["room_id"] = -1
+    info["level"] = _level_for_element(doc, elem)
+    bb = _get_bbox_info(elem)
+    info["bounding_box"] = bb
+    params = []
+    et = doc.GetElement(elem.GetTypeId()) if elem.GetTypeId() else None
+    t = _thickness_mm_from_type(et)
+    if t is not None:
+        params.append({"name": "thickness_mm", "value": round(t, 3)})
+    if bb is not None and bb.get("min") and bb.get("max"):
+        h = abs(bb["max"]["z_mm"] - bb["min"]["z_mm"])
+        params.append({"name": "bbox_height_mm", "value": round(h, 3)})
+    info["parameters"] = params
+    return info
+
+
+def _build_type_info(doc, elem_type):
+    info = _common_header(elem_type)
+    try:
+        info["family_name"] = normalize_string(elem_type.FamilyName)
+    except Exception:
+        pass
+    params = []
+    try:
+        for p in elem_type.Parameters:
+            try:
+                if not p.HasValue or p.IsReadOnly:
+                    continue
+                if not _is_dimension_parameter(p):
+                    continue
+                v = p.AsValueString()
+                if not v:
+                    continue
+                params.append({
+                    "name": normalize_string(p.Definition.Name),
+                    "value": normalize_string(v),
+                })
+            except Exception:
+                continue
+    except Exception:
+        pass
+    t = _thickness_mm_from_type(elem_type)
+    if t is not None:
+        params.append({"name": "thickness_mm", "value": round(t, 3)})
+    info["parameters"] = sorted(params, key=lambda x: (x.get("name") or u""))
+    return info
+
+
+def _build_positioning_info(doc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    if isinstance(elem, DB.Level):
+        info["elevation_mm"] = round(_ft_to_mm(elem.Elevation), 3)
+    elif isinstance(elem, DB.Grid):
+        try:
+            curve = elem.Curve
+            if curve is not None:
+                p0 = curve.GetEndPoint(0)
+                p1 = curve.GetEndPoint(1)
+                info["grid_line"] = {"start_mm": _xyz_to_mm(p0), "end_mm": _xyz_to_mm(p1)}
+        except Exception:
+            pass
+    info["level"] = _level_for_element(doc, elem)
+    return info
+
+
+def _build_spatial_info(doc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    Room = getattr(DB.Architecture, "Room", None) if hasattr(DB, "Architecture") else None
+    Area = getattr(DB, "Area", None)
+    if Room is not None and isinstance(elem, Room):
+        try:
+            info["number"] = normalize_string(elem.Number)
+        except Exception:
+            pass
+        try:
+            vol_ft3 = float(elem.Volume)
+            if vol_ft3:
+                info["volume_m3"] = round(_ft3_to_m3(vol_ft3), 4)
+        except Exception:
+            pass
+    elif Area is not None and isinstance(elem, Area):
+        try:
+            info["number"] = normalize_string(elem.Number)
+        except Exception:
+            pass
+    try:
+        ap = elem.get_Parameter(DB.BuiltInParameter.ROOM_AREA)
+        if ap and ap.HasValue:
+            info["area_m2"] = round(_ft2_to_m2(ap.AsDouble()), 4)
+    except Exception:
+        pass
+    try:
+        pp = elem.get_Parameter(DB.BuiltInParameter.ROOM_PERIMETER)
+        if pp and pp.HasValue:
+            info["perimeter_mm"] = round(_ft_to_mm(pp.AsDouble()), 3)
+    except Exception:
+        pass
+    info["level"] = _level_for_element(doc, elem)
+    return info
+
+
+def _build_view_info(doc, uidoc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    try:
+        info["view_type"] = str(elem.ViewType)
+    except Exception:
+        info["view_type"] = None
+    try:
+        info["scale"] = elem.Scale
+    except Exception:
+        info["scale"] = None
+    try:
+        info["is_template"] = bool(elem.IsTemplate)
+    except Exception:
+        info["is_template"] = None
+    try:
+        info["detail_level"] = str(elem.DetailLevel)
+    except Exception:
+        info["detail_level"] = None
+    if isinstance(elem, DB.ViewPlan):
+        try:
+            lv = elem.GenLevel
+            if lv is not None:
+                info["associated_level"] = {
+                    "id": element_id_value(lv.Id),
+                    "name": normalize_string(lv.Name),
+                    "elevation_mm": round(_ft_to_mm(lv.Elevation), 3),
+                }
+        except Exception:
+            pass
+    info["is_open"] = False
+    info["is_active"] = False
+    try:
+        if uidoc is not None:
+            this_id = element_id_value(elem.Id)
+            for uiv in uidoc.GetOpenUIViews():
+                try:
+                    if element_id_value(uiv.ViewId) == this_id:
+                        info["is_open"] = True
+                        active = uidoc.ActiveView
+                        if active is not None and element_id_value(active.Id) == this_id:
+                            info["is_active"] = True
+                        break
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    return info
+
+
+def _build_annotation_info(doc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    try:
+        if elem.OwnerViewId != DB.ElementId.InvalidElementId:
+            ov = doc.GetElement(elem.OwnerViewId)
+            if ov is not None:
+                info["owner_view"] = normalize_string(ov.Name)
+    except Exception:
+        pass
+    if isinstance(elem, DB.TextNote):
+        try:
+            info["text_content"] = normalize_string(elem.Text)
+        except Exception:
+            pass
+        try:
+            info["position_mm"] = _xyz_to_mm(elem.Coord)
+        except Exception:
+            pass
+    elif isinstance(elem, DB.Dimension):
+        try:
+            v = elem.Value
+            info["dimension_value"] = str(v) if v is not None else None
+        except Exception:
+            pass
+        try:
+            info["position_mm"] = _xyz_to_mm(elem.Origin)
+        except Exception:
+            pass
+    else:
+        try:
+            loc = elem.Location
+            if isinstance(loc, DB.LocationPoint):
+                info["position_mm"] = _xyz_to_mm(loc.Point)
+        except Exception:
+            pass
+    return info
+
+
+def _build_group_or_link_info(doc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    if isinstance(elem, DB.Group):
+        try:
+            members = elem.GetMemberIds()
+            info["member_count"] = len(list(members)) if members is not None else 0
+        except Exception:
+            info["member_count"] = None
+        try:
+            gt = elem.GroupType
+            info["group_type"] = normalize_string(gt.Name) if gt is not None else None
+        except Exception:
+            info["group_type"] = None
+    elif isinstance(elem, DB.RevitLinkInstance):
+        info["link_path"] = None
+        info["link_status"] = None
+        try:
+            link_type = doc.GetElement(elem.GetTypeId())
+            if isinstance(link_type, DB.RevitLinkType):
+                try:
+                    ext = link_type.GetExternalFileReference()
+                    if ext is not None:
+                        path = DB.ModelPathUtils.ConvertModelPathToUserVisiblePath(ext.GetAbsolutePath())
+                        info["link_path"] = normalize_string(path)
+                except Exception:
+                    pass
+                try:
+                    info["link_status"] = str(link_type.GetLinkedFileStatus())
+                except Exception:
+                    pass
+            else:
+                info["link_status"] = "Invalid"
+        except Exception:
+            pass
+        try:
+            loc = elem.Location
+            if isinstance(loc, DB.LocationPoint):
+                info["position_mm"] = _xyz_to_mm(loc.Point)
+        except Exception:
+            pass
+    return info
+
+
+def _build_basic_info(doc, elem):
+    info = _common_header(elem)
+    info["bounding_box"] = _get_bbox_info(elem)
+    return info
+
+
+def _info_for_element(doc, uidoc, elem):
+    """Dispatch on element kind."""
+    try:
+        cat = elem.Category
+    except Exception:
+        cat = None
+
+    # Specific kinds first — many of these (WallType, Room, etc.) inherit
+    # categories whose HasMaterialQuantities=True, so checking that flag
+    # earlier would mis-route them into the generic instance branch.
+    if isinstance(elem, DB.ElementType):
+        return _build_type_info(doc, elem)
+    if isinstance(elem, DB.Level) or isinstance(elem, DB.Grid):
+        return _build_positioning_info(doc, elem)
+    if isinstance(elem, DB.SpatialElement):
+        return _build_spatial_info(doc, elem)
+    if isinstance(elem, DB.View):
+        return _build_view_info(doc, uidoc, elem)
+    annot_types = [DB.TextNote, DB.Dimension, DB.IndependentTag, DB.SpotDimension]
+    AnnotSym = getattr(DB, "AnnotationSymbol", None)
+    if AnnotSym is not None:
+        annot_types.append(AnnotSym)
+    for tp in annot_types:
+        if isinstance(elem, tp):
+            return _build_annotation_info(doc, elem)
+    if isinstance(elem, DB.Group) or isinstance(elem, DB.RevitLinkInstance):
+        return _build_group_or_link_info(doc, elem)
+    # Generic solid-model instance (Wall, Floor, Door, Window, Column, ...)
+    if cat is not None and getattr(cat, "HasMaterialQuantities", False):
+        return _build_instance_info(doc, elem)
+    return _build_basic_info(doc, elem)
+
+
+# ---------- Route ----------
+
+def register_element_filter_routes(api):
+    """Register the structured element filter route."""
+
+    @api.route("/ai_element_filter/", methods=["POST"])
+    def ai_element_filter(doc, uidoc, request):
+        """
+        Find elements matching a structured filter and return rich per-element info.
+
+        See the module docstring for the input schema and per-kind output shape.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+
+            view_or_err, view_source = _resolve_view(doc, data.get("view_id"))
+            if view_or_err == "ERROR":
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": view_source,
+                })
+
+            settings = {"_view_obj": view_or_err if view_or_err is not None else None}
+            ok, err = _validate(data, settings)
+            if not ok:
+                return routes.make_response(data={
+                    "status": "invalid_filter",
+                    "error": err,
+                })
+
+            try:
+                max_elements = int(data.get("max_elements", DEFAULT_MAX_ELEMENTS))
+            except Exception:
+                max_elements = DEFAULT_MAX_ELEMENTS
+
+            applied_filters = []
+            elements = []
+            if settings["include_instances"]:
+                elements.extend(_collect(doc, False, settings, applied_filters))
+            if settings["include_types"]:
+                elements.extend(_collect(doc, True, settings, applied_filters))
+
+            elements = _post_filter_name(elements, settings.get("name_contains"))
+            if settings.get("name_contains"):
+                applied_filters.append("name_contains={}".format(settings["name_contains"]))
+
+            total_matched = len(elements)
+            truncated = False
+            if max_elements > 0 and total_matched > max_elements:
+                elements = elements[:max_elements]
+                truncated = True
+                applied_filters.append("max_elements={}".format(max_elements))
+
+            infos = []
+            for el in elements:
+                try:
+                    info = _info_for_element(doc, uidoc, el)
+                    if info is not None:
+                        infos.append(info)
+                except Exception as ex:
+                    logger.warning("info build failed for id=%s: %s",
+                                   element_id_value(el.Id) if hasattr(el, "Id") else "?", ex)
+                    continue
+
+            return routes.make_response(data={
+                "status": "success",
+                "matched_count": total_matched,
+                "returned_count": len(infos),
+                "truncated": truncated,
+                "applied_filters": applied_filters,
+                "view_source": view_source,
+                "view_id": element_id_value(view_or_err.Id) if view_or_err is not None else None,
+                "view_name": normalize_string(view_or_err.Name) if view_or_err is not None else None,
+                "elements": infos,
+            })
+
+        except Exception as e:
+            logger.error("ai_element_filter failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Element filter (ai_element_filter) routes registered successfully")

--- a/revit_mcp/element_management.py
+++ b/revit_mcp/element_management.py
@@ -1,0 +1,323 @@
+# -*- coding: UTF-8 -*-
+"""
+Element Management Module for Revit MCP
+Delete, modify-parameter, and reset endpoints. All mutating endpoints honour
+a `confirm` flag in the payload — if False (the default), the endpoint
+performs a dry-run lookup and returns what it WOULD do, without modifying
+the model. The MCP-side tool wrappers enforce the same gate at the
+user-facing layer.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+# Categories considered "process" content for reset_model — geometry the user
+# would typically generate or import, NOT views/levels/sheets/families/types.
+# Bias toward leaving the project skeleton intact unless the caller explicitly
+# expands the list.
+_DEFAULT_RESET_CATEGORIES = [
+    DB.BuiltInCategory.OST_Walls,
+    DB.BuiltInCategory.OST_Floors,
+    DB.BuiltInCategory.OST_Ceilings,
+    DB.BuiltInCategory.OST_Roofs,
+    DB.BuiltInCategory.OST_Doors,
+    DB.BuiltInCategory.OST_Windows,
+    DB.BuiltInCategory.OST_Furniture,
+    DB.BuiltInCategory.OST_GenericModel,
+    DB.BuiltInCategory.OST_Stairs,
+    DB.BuiltInCategory.OST_Railings,
+    DB.BuiltInCategory.OST_Columns,
+    DB.BuiltInCategory.OST_StructuralFraming,
+    DB.BuiltInCategory.OST_StructuralColumns,
+    DB.BuiltInCategory.OST_StructuralFoundation,
+]
+
+
+def _category_name_to_bic(name):
+    """Map a friendly category name (e.g. 'walls') to BuiltInCategory."""
+    if not name:
+        return None
+    key = name.strip().lower().replace(" ", "_").replace("-", "_")
+    aliases = {
+        "wall": DB.BuiltInCategory.OST_Walls,
+        "walls": DB.BuiltInCategory.OST_Walls,
+        "floor": DB.BuiltInCategory.OST_Floors,
+        "floors": DB.BuiltInCategory.OST_Floors,
+        "ceiling": DB.BuiltInCategory.OST_Ceilings,
+        "ceilings": DB.BuiltInCategory.OST_Ceilings,
+        "roof": DB.BuiltInCategory.OST_Roofs,
+        "roofs": DB.BuiltInCategory.OST_Roofs,
+        "door": DB.BuiltInCategory.OST_Doors,
+        "doors": DB.BuiltInCategory.OST_Doors,
+        "window": DB.BuiltInCategory.OST_Windows,
+        "windows": DB.BuiltInCategory.OST_Windows,
+        "furniture": DB.BuiltInCategory.OST_Furniture,
+        "generic_model": DB.BuiltInCategory.OST_GenericModel,
+        "stair": DB.BuiltInCategory.OST_Stairs,
+        "stairs": DB.BuiltInCategory.OST_Stairs,
+        "railing": DB.BuiltInCategory.OST_Railings,
+        "railings": DB.BuiltInCategory.OST_Railings,
+        "column": DB.BuiltInCategory.OST_Columns,
+        "columns": DB.BuiltInCategory.OST_Columns,
+        "structural_framing": DB.BuiltInCategory.OST_StructuralFraming,
+        "structural_columns": DB.BuiltInCategory.OST_StructuralColumns,
+        "structural_foundation": DB.BuiltInCategory.OST_StructuralFoundation,
+    }
+    return aliases.get(key)
+
+
+def register_element_management_routes(api):
+    """Register delete / modify / reset endpoints."""
+
+    @api.route("/delete_elements/", methods=["POST"])
+    def delete_elements(doc, request):
+        """
+        Delete elements by ID.
+
+        Expected payload:
+        {
+            "element_ids": [12345, 67890],
+            "confirm": false                 // must be true to actually delete
+        }
+
+        If confirm=false: returns a preview of what would be deleted (id, name, category).
+        If confirm=true:  runs the delete inside a single transaction.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+            data = _parse_json_request(request)
+            ids = data.get("element_ids") or []
+            confirm = bool(data.get("confirm", False))
+            if not isinstance(ids, list) or not ids:
+                return routes.make_response(data={"error": "element_ids must be a non-empty list of integers"}, status=400)
+
+            # Lookup phase (always runs)
+            preview = []
+            valid_ids = []
+            for raw_id in ids:
+                try:
+                    eid = DB.ElementId(int(raw_id))
+                    el = doc.GetElement(eid)
+                    if el is None:
+                        preview.append({"id": int(raw_id), "status": "not_found"})
+                        continue
+                    cat = el.Category
+                    preview.append({
+                        "id": int(raw_id),
+                        "name": normalize_string(get_element_name(el)),
+                        "category": normalize_string(cat.Name) if cat else u"(no category)",
+                        "status": "would_delete",
+                    })
+                    valid_ids.append(eid)
+                except Exception as ex:
+                    preview.append({"id": raw_id, "status": "error", "error": str(ex)})
+
+            if not confirm:
+                return routes.make_response(data={
+                    "status": "preview",
+                    "confirm_required": True,
+                    "would_delete_count": len(valid_ids),
+                    "preview": preview,
+                    "hint": "Re-call with confirm=true to actually delete.",
+                })
+
+            if not valid_ids:
+                return routes.make_response(data={
+                    "status": "no_op",
+                    "preview": preview,
+                    "message": "No valid element IDs to delete.",
+                })
+
+            with DB.Transaction(doc, "MCP: Delete Elements") as t:
+                t.Start()
+                from System.Collections.Generic import List as NetList
+                id_list = NetList[DB.ElementId]()
+                for eid in valid_ids:
+                    id_list.Add(eid)
+                deleted = doc.Delete(id_list)
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "deleted_count": len(deleted),
+                "deleted_ids": [element_id_value(d) for d in deleted],
+                "preview": preview,
+            })
+
+        except Exception as e:
+            logger.error("delete_elements failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/modify_element/", methods=["POST"])
+    def modify_element(doc, request):
+        """
+        Modify instance parameters of a single element.
+
+        Expected payload:
+        {
+            "element_id": 12345,
+            "parameters": {
+                "Comments": "Updated via MCP",
+                "Mark": "A1"
+            }
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+            data = _parse_json_request(request)
+            raw_id = data.get("element_id")
+            params = data.get("parameters") or {}
+            if raw_id is None:
+                return routes.make_response(data={"error": "Missing element_id"}, status=400)
+            if not isinstance(params, dict) or not params:
+                return routes.make_response(data={"error": "parameters must be a non-empty dict"}, status=400)
+
+            eid = DB.ElementId(int(raw_id))
+            el = doc.GetElement(eid)
+            if el is None:
+                return routes.make_response(data={"error": "Element {} not found".format(raw_id)}, status=404)
+
+            results = []
+            with DB.Transaction(doc, "MCP: Modify Element") as t:
+                t.Start()
+                for name, value in params.items():
+                    try:
+                        p = el.LookupParameter(name)
+                        if p is None:
+                            results.append({"parameter": name, "status": "not_found"})
+                            continue
+                        if p.IsReadOnly:
+                            results.append({"parameter": name, "status": "read_only"})
+                            continue
+                        st = p.StorageType
+                        if st == DB.StorageType.String:
+                            p.Set(unicode(value) if isinstance(value, str) else value)
+                        elif st == DB.StorageType.Integer:
+                            p.Set(int(value))
+                        elif st == DB.StorageType.Double:
+                            p.Set(float(value))
+                        elif st == DB.StorageType.ElementId:
+                            p.Set(DB.ElementId(int(value)))
+                        else:
+                            results.append({"parameter": name, "status": "unsupported_storage_type", "storage": str(st)})
+                            continue
+                        results.append({"parameter": name, "status": "set", "value": value})
+                    except Exception as pe:
+                        results.append({"parameter": name, "status": "error", "error": str(pe)})
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "element_id": int(raw_id),
+                "element_name": normalize_string(get_element_name(el)),
+                "results": results,
+            })
+
+        except Exception as e:
+            logger.error("modify_element failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/reset_model/", methods=["POST"])
+    def reset_model(doc, request):
+        """
+        Delete all instances of the specified categories. DESTRUCTIVE.
+
+        Expected payload:
+        {
+            "categories": ["walls", "doors", "windows"],   // optional; defaults to a built-in safe set
+            "confirm": false                                // must be true to execute
+        }
+
+        Always returns a preview first. Only proceeds when confirm=true.
+        Does NOT delete views, levels, sheets, family types, or other "project skeleton" content.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+            data = _parse_json_request(request)
+            confirm = bool(data.get("confirm", False))
+            requested = data.get("categories")
+
+            if requested:
+                bics = []
+                unknown = []
+                for name in requested:
+                    bic = _category_name_to_bic(name)
+                    if bic is None:
+                        unknown.append(name)
+                    else:
+                        bics.append(bic)
+                if unknown:
+                    return routes.make_response(data={
+                        "error": "Unknown categories: {}. Supported: walls, floors, ceilings, roofs, doors, windows, furniture, generic_model, stairs, railings, columns, structural_framing, structural_columns, structural_foundation".format(unknown),
+                    }, status=400)
+            else:
+                bics = list(_DEFAULT_RESET_CATEGORIES)
+
+            # Lookup phase
+            preview_by_cat = {}
+            all_ids = []
+            for bic in bics:
+                try:
+                    cat_name = str(bic).split(".")[-1]
+                except Exception:
+                    cat_name = u"?"
+                col = (DB.FilteredElementCollector(doc)
+                       .OfCategory(bic)
+                       .WhereElementIsNotElementType())
+                ids = [el.Id for el in col]
+                preview_by_cat[cat_name] = len(ids)
+                all_ids.extend(ids)
+
+            if not confirm:
+                return routes.make_response(data={
+                    "status": "preview",
+                    "confirm_required": True,
+                    "would_delete_total": len(all_ids),
+                    "would_delete_by_category": preview_by_cat,
+                    "hint": "Re-call with confirm=true to actually wipe. DESTRUCTIVE — undo only via Revit's own undo stack.",
+                })
+
+            if not all_ids:
+                return routes.make_response(data={
+                    "status": "no_op",
+                    "by_category": preview_by_cat,
+                    "message": "Nothing to delete in the requested categories.",
+                })
+
+            with DB.Transaction(doc, "MCP: Reset Model") as t:
+                t.Start()
+                from System.Collections.Generic import List as NetList
+                id_list = NetList[DB.ElementId]()
+                for eid in all_ids:
+                    id_list.Add(eid)
+                deleted = doc.Delete(id_list)
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "deleted_count": len(deleted),
+                "by_category_attempted": preview_by_cat,
+            })
+
+        except Exception as e:
+            logger.error("reset_model failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Element-management routes registered successfully")

--- a/revit_mcp/element_management.py
+++ b/revit_mcp/element_management.py
@@ -10,6 +10,7 @@ user-facing layer.
 
 from pyrevit import routes, revit, DB
 from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
 import json
 import traceback
 import logging
@@ -111,7 +112,7 @@ def register_element_management_routes(api):
             valid_ids = []
             for raw_id in ids:
                 try:
-                    eid = DB.ElementId(int(raw_id))
+                    eid = DB.ElementId(Int64(int(raw_id)))
                     el = doc.GetElement(eid)
                     if el is None:
                         preview.append({"id": int(raw_id), "status": "not_found"})
@@ -188,7 +189,7 @@ def register_element_management_routes(api):
             if not isinstance(params, dict) or not params:
                 return routes.make_response(data={"error": "parameters must be a non-empty dict"}, status=400)
 
-            eid = DB.ElementId(int(raw_id))
+            eid = DB.ElementId(Int64(int(raw_id)))
             el = doc.GetElement(eid)
             if el is None:
                 return routes.make_response(data={"error": "Element {} not found".format(raw_id)}, status=404)
@@ -213,7 +214,7 @@ def register_element_management_routes(api):
                         elif st == DB.StorageType.Double:
                             p.Set(float(value))
                         elif st == DB.StorageType.ElementId:
-                            p.Set(DB.ElementId(int(value)))
+                            p.Set(DB.ElementId(Int64(int(value))))
                         else:
                             results.append({"parameter": name, "status": "unsupported_storage_type", "storage": str(st)})
                             continue

--- a/revit_mcp/element_operations.py
+++ b/revit_mcp/element_operations.py
@@ -19,13 +19,14 @@ Supported actions (case-insensitive):
     reset_isolate    -- clear the temporary hide/isolate view mode
     delete           -- delete elements (confirm-gated; preview unless confirm)
 
+Note: every view-state mutation here -- including the temporary view modes
+(temp_hide / isolate / reset_isolate) -- is a transactional document change
+and runs inside a DB.Transaction. `select` is the only action that does not
+(UI selection is not a model change).
+
 Differences from the Sparx C# original:
   * Revit 2026: ElementId is built via a System.Int64 cast -- the bare int
     ctor `ElementId(int)` is ambiguous/removed on Revit 2026.
-  * The temporary view-mode calls (HideElementsTemporary / IsolateElements-
-    Temporary / DisableTemporaryViewMode) MUST NOT run inside a transaction
-    -- the Revit API forbids it. Sparx wraps all three in a Transaction, so
-    those actions throw. This port runs them transaction-free.
   * Returns structured statuses (element_not_found, not_3d_view, no_3d_view,
     no_bounding_box, invalid_color, ...) instead of throwing generic
     exceptions.
@@ -444,9 +445,12 @@ def register_element_operations_routes(api):
                 resp.update(view_meta)
                 return routes.make_response(data=resp)
 
-            # ===== TEMPORARY VIEW MODES (no transaction -- API forbids it) =====
+            # ===== TEMPORARY VIEW MODES (transactional view-state changes) =====
             if action == "temp_hide":
-                target_view.HideElementsTemporary(_id_collection(elem_ids))
+                with DB.Transaction(doc, "MCP: Operate Element (temp_hide)") as t:
+                    t.Start()
+                    target_view.HideElementsTemporary(_id_collection(elem_ids))
+                    t.Commit()
                 resp = {
                     "status": "success", "action": "temp_hide",
                     "affected_count": len(elem_ids),
@@ -459,7 +463,10 @@ def register_element_operations_routes(api):
                 return routes.make_response(data=resp)
 
             if action == "isolate":
-                target_view.IsolateElementsTemporary(_id_collection(elem_ids))
+                with DB.Transaction(doc, "MCP: Operate Element (isolate)") as t:
+                    t.Start()
+                    target_view.IsolateElementsTemporary(_id_collection(elem_ids))
+                    t.Commit()
                 resp = {
                     "status": "success", "action": "isolate",
                     "affected_count": len(elem_ids),
@@ -472,8 +479,11 @@ def register_element_operations_routes(api):
                 return routes.make_response(data=resp)
 
             if action == "reset_isolate":
-                target_view.DisableTemporaryViewMode(
-                    DB.TemporaryViewMode.TemporaryHideIsolate)
+                with DB.Transaction(doc, "MCP: Operate Element (reset_isolate)") as t:
+                    t.Start()
+                    target_view.DisableTemporaryViewMode(
+                        DB.TemporaryViewMode.TemporaryHideIsolate)
+                    t.Commit()
                 resp = {
                     "status": "success", "action": "reset_isolate",
                 }

--- a/revit_mcp/element_operations.py
+++ b/revit_mcp/element_operations.py
@@ -1,0 +1,496 @@
+# -*- coding: UTF-8 -*-
+"""
+Element Operations Module for Revit MCP
+
+A single multi-action endpoint that performs view-state, selection, and
+visibility operations on a set of elements. Ported from the Sparx
+mcp-servers-for-revit `OperateElementCommand` / `OperateElementEventHandler`.
+
+Supported actions (case-insensitive):
+
+    select           -- set the Revit UI selection to the given elements
+    selection_box    -- enable a 3D section box around the given elements
+    set_color        -- override projection/cut/surface colour in a view
+    set_transparency -- override surface transparency (0-100) in a view
+    hide             -- permanently hide elements in a view
+    unhide           -- un-hide elements in a view
+    temp_hide        -- temporarily hide elements (session-only view mode)
+    isolate          -- temporarily isolate elements (session-only view mode)
+    reset_isolate    -- clear the temporary hide/isolate view mode
+    delete           -- delete elements (confirm-gated; preview unless confirm)
+
+Differences from the Sparx C# original:
+  * Revit 2026: ElementId is built via a System.Int64 cast -- the bare int
+    ctor `ElementId(int)` is ambiguous/removed on Revit 2026.
+  * The temporary view-mode calls (HideElementsTemporary / IsolateElements-
+    Temporary / DisableTemporaryViewMode) MUST NOT run inside a transaction
+    -- the Revit API forbids it. Sparx wraps all three in a Transaction, so
+    those actions throw. This port runs them transaction-free.
+  * Returns structured statuses (element_not_found, not_3d_view, no_3d_view,
+    no_bounding_box, invalid_color, ...) instead of throwing generic
+    exceptions.
+  * Per-element id validation -- unresolved ids are collected in `invalid_ids`
+    and the operation proceeds on the valid subset instead of NRE-ing.
+  * The `delete` action is confirm-gated (Sparx deletes unconditionally).
+  * Optional `view_id` targets a specific view instead of always mutating the
+    active view; when a 3D view must be activated for `selection_box` the
+    switch is reported (`view_switched`, `previous_view_name`).
+  * `hide` filters by Element.CanBeHidden(view) so a single un-hideable
+    element does not abort the whole batch.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
+from System.Collections.Generic import List as NetList
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_ACTIONS = frozenset([
+    "select", "selection_box", "set_color", "set_transparency",
+    "hide", "unhide", "temp_hide", "isolate", "reset_isolate", "delete",
+])
+# Actions that do not require an element_ids list.
+_NO_ELEMENT_ACTIONS = frozenset(["reset_isolate"])
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _id_collection(ids):
+    """Build a .NET ICollection[ElementId] from an iterable of ElementId."""
+    coll = NetList[DB.ElementId]()
+    for eid in ids:
+        coll.Add(eid)
+    return coll
+
+
+def _is_number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _valid_color(color):
+    return (isinstance(color, (list, tuple)) and len(color) >= 3 and
+            all(_is_number(c) for c in color[:3]))
+
+
+def _ft_to_mm(value):
+    return round(DB.UnitUtils.ConvertFromInternalUnits(
+        value, DB.UnitTypeId.Millimeters), 2)
+
+
+def _resolve_view(doc, view_id):
+    """Return (view, error) where error is None / 'invalid' / 'not_found'."""
+    if view_id is None:
+        return doc.ActiveView, None
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return None, "invalid"
+    view = doc.GetElement(vid)
+    if view is None or not isinstance(view, DB.View):
+        return None, "not_found"
+    return view, None
+
+
+def _find_solid_fill_pattern(doc):
+    """First solid-fill FillPatternElement in the document, or None."""
+    try:
+        for p in DB.FilteredElementCollector(doc).OfClass(DB.FillPatternElement):
+            fp = p.GetFillPattern()
+            if fp is not None and fp.IsSolidFill:
+                return p
+    except Exception:
+        pass
+    return None
+
+
+def _apply_selection_box(doc, uidoc, valid_elems, elem_ids, invalid_ids, view_id):
+    """Enable a 3D section box around the given elements."""
+    # Resolve a 3D view to host the section box.
+    if view_id is not None:
+        view3d, err = _resolve_view(doc, view_id)
+        if err == "invalid":
+            return routes.make_response(
+                data={"error": "view_id must be an integer"}, status=400)
+        if view3d is None:
+            return routes.make_response(data={
+                "status": "view_not_found",
+                "error": "No view found for view_id={}.".format(view_id),
+            })
+        if not isinstance(view3d, DB.View3D):
+            return routes.make_response(data={
+                "status": "not_3d_view",
+                "error": "view_id={} is not a 3D view; selection_box needs a "
+                         "3D view.".format(view_id),
+            })
+    elif isinstance(doc.ActiveView, DB.View3D):
+        view3d = doc.ActiveView
+    else:
+        view3d = None
+        for v in DB.FilteredElementCollector(doc).OfClass(DB.View3D):
+            if not v.IsTemplate:
+                view3d = v
+                break
+        if view3d is None:
+            return routes.make_response(data={
+                "status": "no_3d_view",
+                "error": "No non-template 3D view exists to host a section box.",
+            })
+
+    # Union the element bounding boxes (model coordinates, feet).
+    bb_min = None
+    bb_max = None
+    without_bbox = []
+    for (eid, el) in valid_elems:
+        eb = el.get_BoundingBox(None)
+        if eb is None:
+            without_bbox.append(element_id_value(eid))
+            continue
+        lo = [eb.Min.X, eb.Min.Y, eb.Min.Z]
+        hi = [eb.Max.X, eb.Max.Y, eb.Max.Z]
+        if bb_min is None:
+            bb_min, bb_max = lo, hi
+        else:
+            bb_min = [min(bb_min[i], lo[i]) for i in range(3)]
+            bb_max = [max(bb_max[i], hi[i]) for i in range(3)]
+
+    if bb_min is None:
+        return routes.make_response(data={
+            "status": "no_bounding_box",
+            "error": "None of the supplied elements have a bounding box.",
+            "invalid_ids": invalid_ids,
+        })
+
+    offset = 1.0  # 1 ft of padding so the box sits slightly proud of the geometry
+    box = DB.BoundingBoxXYZ()
+    box.Min = DB.XYZ(bb_min[0] - offset, bb_min[1] - offset, bb_min[2] - offset)
+    box.Max = DB.XYZ(bb_max[0] + offset, bb_max[1] + offset, bb_max[2] + offset)
+
+    with DB.Transaction(doc, "MCP: Operate Element (selection_box)") as t:
+        t.Start()
+        view3d.IsSectionBoxActive = True
+        view3d.SetSectionBox(box)
+        t.Commit()
+
+    # Activate the 3D view if it is not already current, then scroll to the
+    # elements. The switch is opt-out-able only by passing an already-active
+    # view_id; either way it is reported.
+    view_switched = False
+    previous_view_name = None
+    if element_id_value(doc.ActiveView.Id) != element_id_value(view3d.Id):
+        previous_view_name = normalize_string(get_element_name(doc.ActiveView))
+        uidoc.ActiveView = view3d
+        view_switched = True
+    uidoc.ShowElements(_id_collection(elem_ids))
+
+    return routes.make_response(data={
+        "status": "success",
+        "action": "selection_box",
+        "view_id": element_id_value(view3d.Id),
+        "view_name": normalize_string(get_element_name(view3d)),
+        "view_switched": view_switched,
+        "previous_view_name": previous_view_name,
+        "section_box_min_mm": [_ft_to_mm(box.Min.X), _ft_to_mm(box.Min.Y), _ft_to_mm(box.Min.Z)],
+        "section_box_max_mm": [_ft_to_mm(box.Max.X), _ft_to_mm(box.Max.Y), _ft_to_mm(box.Max.Z)],
+        "affected_count": len(elem_ids),
+        "affected_ids": [element_id_value(e) for e in elem_ids],
+        "elements_without_bbox": without_bbox,
+        "invalid_ids": invalid_ids,
+    })
+
+
+def register_element_operations_routes(api):
+    """Register the multi-action /operate_element/ endpoint."""
+
+    @api.route("/operate_element/", methods=["POST"])
+    def operate_element(doc, request):
+        """Run a view-state / selection / visibility operation on elements."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            action = str(data.get("action", "")).strip().lower()
+            raw_ids = data.get("element_ids") or []
+            confirm = bool(data.get("confirm", False))
+            view_id = data.get("view_id")
+
+            if action not in _VALID_ACTIONS:
+                return routes.make_response(data={
+                    "status": "unsupported_action",
+                    "error": "Unsupported action '{}'.".format(action),
+                    "valid_actions": sorted(_VALID_ACTIONS),
+                })
+
+            if not isinstance(raw_ids, list):
+                return routes.make_response(data={
+                    "error": "element_ids must be a list of integers"}, status=400)
+
+            if not raw_ids and action not in _NO_ELEMENT_ACTIONS:
+                return routes.make_response(data={
+                    "status": "no_elements",
+                    "error": "Action '{}' requires a non-empty element_ids "
+                             "list.".format(action),
+                })
+
+            uidoc = revit.uidoc
+            if not uidoc:
+                return routes.make_response(
+                    data={"error": "No active Revit UI document"}, status=503)
+
+            # --- Resolve & validate element ids ---
+            valid_elems = []   # list of (ElementId, Element)
+            invalid_ids = []
+            for raw in raw_ids:
+                try:
+                    eid = DB.ElementId(Int64(int(raw)))
+                except Exception:
+                    invalid_ids.append(raw)
+                    continue
+                el = doc.GetElement(eid)
+                if el is None:
+                    invalid_ids.append(int(raw))
+                else:
+                    valid_elems.append((eid, el))
+
+            if not valid_elems and action not in _NO_ELEMENT_ACTIONS:
+                return routes.make_response(data={
+                    "status": "element_not_found",
+                    "error": "None of the supplied element_ids resolved to "
+                             "elements in the active document.",
+                    "invalid_ids": invalid_ids,
+                })
+
+            elem_ids = [eid for (eid, _el) in valid_elems]
+
+            # ===== SELECT (no transaction) =====
+            if action == "select":
+                uidoc.Selection.SetElementIds(_id_collection(elem_ids))
+                return routes.make_response(data={
+                    "status": "success",
+                    "action": "select",
+                    "selected_count": len(elem_ids),
+                    "selected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                })
+
+            # ===== SELECTION BOX (3D section box) =====
+            if action == "selection_box":
+                return _apply_selection_box(
+                    doc, uidoc, valid_elems, elem_ids, invalid_ids, view_id)
+
+            # ===== DELETE (confirm-gated) =====
+            if action == "delete":
+                preview = []
+                for (eid, el) in valid_elems:
+                    cat = el.Category
+                    preview.append({
+                        "id": element_id_value(eid),
+                        "name": normalize_string(get_element_name(el)),
+                        "category": normalize_string(cat.Name) if cat else u"(no category)",
+                    })
+                if not confirm:
+                    return routes.make_response(data={
+                        "status": "preview",
+                        "action": "delete",
+                        "confirm_required": True,
+                        "would_delete_count": len(preview),
+                        "would_delete": preview,
+                        "invalid_ids": invalid_ids,
+                        "hint": "Re-call with confirm=true to delete. For "
+                                "delete-only work prefer the delete_elements tool.",
+                    })
+                with DB.Transaction(doc, "MCP: Operate Element (delete)") as t:
+                    t.Start()
+                    deleted = doc.Delete(_id_collection(elem_ids))
+                    t.Commit()
+                return routes.make_response(data={
+                    "status": "success",
+                    "action": "delete",
+                    "deleted_count": len(deleted),
+                    "deleted_ids": [element_id_value(d) for d in deleted],
+                    "invalid_ids": invalid_ids,
+                })
+
+            # --- Remaining actions are view-scoped; resolve the target view ---
+            target_view, verr = _resolve_view(doc, view_id)
+            if verr == "invalid":
+                return routes.make_response(
+                    data={"error": "view_id must be an integer"}, status=400)
+            if target_view is None:
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": "No view found for view_id={}.".format(view_id),
+                })
+            view_meta = {
+                "view_id": element_id_value(target_view.Id),
+                "view_name": normalize_string(get_element_name(target_view)),
+            }
+
+            # ===== SET COLOR =====
+            if action == "set_color":
+                color = data.get("color")
+                if not _valid_color(color):
+                    return routes.make_response(data={
+                        "status": "invalid_color",
+                        "error": "set_color requires 'color' as [r, g, b] with "
+                                 "values 0-255.",
+                    })
+                r, g, b = [max(0, min(255, int(c))) for c in color[:3]]
+                ogs = DB.OverrideGraphicSettings()
+                rev_color = DB.Color(r, g, b)
+                ogs.SetProjectionLineColor(rev_color)
+                ogs.SetCutLineColor(rev_color)
+                ogs.SetSurfaceForegroundPatternColor(rev_color)
+                ogs.SetSurfaceBackgroundPatternColor(rev_color)
+                solid = _find_solid_fill_pattern(doc)
+                if solid is not None:
+                    ogs.SetSurfaceForegroundPatternId(solid.Id)
+                    ogs.SetSurfaceForegroundPatternVisible(True)
+                with DB.Transaction(doc, "MCP: Operate Element (set_color)") as t:
+                    t.Start()
+                    for eid in elem_ids:
+                        target_view.SetElementOverrides(eid, ogs)
+                    t.Commit()
+                resp = {
+                    "status": "success", "action": "set_color",
+                    "color": [r, g, b],
+                    "affected_count": len(elem_ids),
+                    "affected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            # ===== SET TRANSPARENCY =====
+            if action == "set_transparency":
+                transparency = data.get("transparency")
+                if not _is_number(transparency):
+                    return routes.make_response(data={
+                        "status": "invalid_transparency",
+                        "error": "set_transparency requires 'transparency' as a "
+                                 "number 0-100.",
+                    })
+                tval = max(0, min(100, int(transparency)))
+                ogs = DB.OverrideGraphicSettings()
+                ogs.SetSurfaceTransparency(tval)
+                with DB.Transaction(doc, "MCP: Operate Element (set_transparency)") as t:
+                    t.Start()
+                    for eid in elem_ids:
+                        target_view.SetElementOverrides(eid, ogs)
+                    t.Commit()
+                resp = {
+                    "status": "success", "action": "set_transparency",
+                    "transparency": tval,
+                    "affected_count": len(elem_ids),
+                    "affected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            # ===== HIDE (permanent) =====
+            if action == "hide":
+                hideable = []
+                skipped = []
+                for (eid, el) in valid_elems:
+                    try:
+                        can_hide = el.CanBeHidden(target_view)
+                    except Exception:
+                        can_hide = False
+                    (hideable if can_hide else skipped).append(eid)
+                if not hideable:
+                    return routes.make_response(data={
+                        "status": "nothing_to_hide",
+                        "error": "None of the elements can be hidden in this view.",
+                        "skipped_cannot_hide": [element_id_value(e) for e in skipped],
+                    })
+                with DB.Transaction(doc, "MCP: Operate Element (hide)") as t:
+                    t.Start()
+                    target_view.HideElements(_id_collection(hideable))
+                    t.Commit()
+                resp = {
+                    "status": "success", "action": "hide",
+                    "affected_count": len(hideable),
+                    "affected_ids": [element_id_value(e) for e in hideable],
+                    "skipped_cannot_hide": [element_id_value(e) for e in skipped],
+                    "invalid_ids": invalid_ids,
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            # ===== UNHIDE (permanent) =====
+            if action == "unhide":
+                with DB.Transaction(doc, "MCP: Operate Element (unhide)") as t:
+                    t.Start()
+                    target_view.UnhideElements(_id_collection(elem_ids))
+                    t.Commit()
+                resp = {
+                    "status": "success", "action": "unhide",
+                    "affected_count": len(elem_ids),
+                    "affected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            # ===== TEMPORARY VIEW MODES (no transaction -- API forbids it) =====
+            if action == "temp_hide":
+                target_view.HideElementsTemporary(_id_collection(elem_ids))
+                resp = {
+                    "status": "success", "action": "temp_hide",
+                    "affected_count": len(elem_ids),
+                    "affected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                    "note": "Temporary -- cleared by action=reset_isolate or "
+                            "Revit's temporary view-mode toolbar.",
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            if action == "isolate":
+                target_view.IsolateElementsTemporary(_id_collection(elem_ids))
+                resp = {
+                    "status": "success", "action": "isolate",
+                    "affected_count": len(elem_ids),
+                    "affected_ids": [element_id_value(e) for e in elem_ids],
+                    "invalid_ids": invalid_ids,
+                    "note": "Temporary -- cleared by action=reset_isolate or "
+                            "Revit's temporary view-mode toolbar.",
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            if action == "reset_isolate":
+                target_view.DisableTemporaryViewMode(
+                    DB.TemporaryViewMode.TemporaryHideIsolate)
+                resp = {
+                    "status": "success", "action": "reset_isolate",
+                }
+                resp.update(view_meta)
+                return routes.make_response(data=resp)
+
+            # Should be unreachable -- every valid action is handled above.
+            return routes.make_response(data={
+                "status": "unsupported_action",
+                "error": "Action '{}' has no handler.".format(action),
+            })
+
+        except Exception as e:
+            import traceback
+            logger.error("operate_element failed: {}".format(traceback.format_exc()))
+            return routes.make_response(
+                data={"error": str(e), "traceback": traceback.format_exc()},
+                status=500)
+
+    logger.info("Element-operations routes registered successfully")

--- a/revit_mcp/grids.py
+++ b/revit_mcp/grids.py
@@ -1,0 +1,259 @@
+# -*- coding: UTF-8 -*-
+"""
+Grids Module for Revit MCP
+Generates a project grid from existing wall centerlines:
+- Vertical grids (constant X) numbered 1, 2, 3, ... from LEFT (smallest X)
+- Horizontal grids (constant Y) lettered A, B, C, ... AA, AB, ... from SOUTH (smallest Y)
+
+Only axis-aligned walls contribute. Diagonal and curved walls are reported
+but skipped. Walls whose centerlines are within `tolerance_mm` (default
+10 mm) of each other on the same axis collapse into a single grid line.
+
+All grids are created inside one transaction so the entire grid system
+can be undone with a single Ctrl+Z.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def _mm_to_feet(value_mm):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _ft_to_mm(value_ft):
+    return value_ft * 304.8
+
+
+def _alpha_name(i, start_letter="A"):
+    """Excel-style spreadsheet column naming. 0 -> 'A', 25 -> 'Z', 26 -> 'AA', ..."""
+    if start_letter and len(start_letter) == 1 and "A" <= start_letter.upper() <= "Z":
+        offset = ord(start_letter.upper()) - ord("A")
+    else:
+        offset = 0
+    s = ""
+    n = i + 1 + offset
+    while n > 0:
+        n, r = divmod(n - 1, 26)
+        s = chr(ord("A") + r) + s
+    return s
+
+
+def _dedupe(values, tol):
+    """Merge near-duplicate floats within `tol` into a single averaged value."""
+    out = []
+    for v in sorted(values):
+        if not out or abs(v - out[-1]) > tol:
+            out.append(v)
+        else:
+            out[-1] = (out[-1] + v) / 2.0
+    return out
+
+
+def register_grids_routes(api):
+    """Register grid-generation routes."""
+
+    @api.route("/create_grids_from_walls/", methods=["POST"])
+    def create_grids_from_walls(doc, request):
+        """
+        Create a grid system from axis-aligned wall centerlines.
+
+        Expected payload (all optional):
+        {
+            "tolerance_mm":         10.0,   # collapse near-duplicate centerlines within this distance
+            "padding_mm":           3000.0, # extend grid lines beyond the building bbox by this much
+            "start_vertical_number": 1,     # first number for vertical grids ("1", "2", ...)
+            "start_horizontal_letter":"A",  # first letter for horizontal grids ("A", "B", ...)
+            "vertical_prefix":     "",      # prefix prepended to each vertical grid name (e.g. "V-")
+            "horizontal_prefix":   "",      # prefix prepended to each horizontal grid name (e.g. "H-")
+            "dry_run":             false    # if true, report what would be created without modifying the model
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            tolerance_mm = float(data.get("tolerance_mm", 10.0))
+            padding_mm = float(data.get("padding_mm", 3000.0))
+            start_v_num = int(data.get("start_vertical_number", 1))
+            start_h_letter = str(data.get("start_horizontal_letter", "A") or "A")
+            v_prefix = str(data.get("vertical_prefix", "") or "")
+            h_prefix = str(data.get("horizontal_prefix", "") or "")
+            dry_run = bool(data.get("dry_run", False))
+
+            tol_ft = _mm_to_feet(tolerance_mm)
+            pad_ft = _mm_to_feet(padding_mm)
+
+            walls = list(DB.FilteredElementCollector(doc)
+                         .OfCategory(DB.BuiltInCategory.OST_Walls)
+                         .WhereElementIsNotElementType())
+            if not walls:
+                return routes.make_response(data={
+                    "status": "no_walls",
+                    "error": "No walls in the active document.",
+                    "document_title": normalize_string(doc.Title),
+                })
+
+            vertical_xs = []
+            horizontal_ys = []
+            all_xs, all_ys = [], []
+            skipped_diagonal = 0
+            skipped_curved = 0
+            skipped_non_curve = 0
+
+            for w in walls:
+                loc = w.Location
+                if not isinstance(loc, DB.LocationCurve):
+                    skipped_non_curve += 1
+                    continue
+                curve = loc.Curve
+                if not isinstance(curve, DB.Line):
+                    skipped_curved += 1
+                    continue
+                p0 = curve.GetEndPoint(0)
+                p1 = curve.GetEndPoint(1)
+                dx = p1.X - p0.X
+                dy = p1.Y - p0.Y
+                if abs(dx) < tol_ft and abs(dy) > tol_ft:
+                    vertical_xs.append((p0.X + p1.X) / 2.0)
+                elif abs(dy) < tol_ft and abs(dx) > tol_ft:
+                    horizontal_ys.append((p0.Y + p1.Y) / 2.0)
+                else:
+                    skipped_diagonal += 1
+                    continue
+                all_xs.append(p0.X); all_xs.append(p1.X)
+                all_ys.append(p0.Y); all_ys.append(p1.Y)
+
+            if not vertical_xs and not horizontal_ys:
+                return routes.make_response(data={
+                    "status": "no_axis_aligned_walls",
+                    "error": "Walls found but none are axis-aligned. Cannot generate axis-aligned grids.",
+                    "walls_scanned": len(walls),
+                    "skipped_diagonal": skipped_diagonal,
+                    "skipped_curved": skipped_curved,
+                })
+
+            xs = _dedupe(vertical_xs, tol_ft)
+            ys = _dedupe(horizontal_ys, tol_ft)
+
+            min_x = min(all_xs) - pad_ft
+            max_x = max(all_xs) + pad_ft
+            min_y = min(all_ys) - pad_ft
+            max_y = max(all_ys) + pad_ft
+
+            # Build planned grid list (used by both dry-run and the real path)
+            planned_v = []
+            for i, x in enumerate(xs):
+                name = "{}{}".format(v_prefix, start_v_num + i)
+                planned_v.append({"name": name, "x_mm": round(_ft_to_mm(x), 3)})
+            planned_h = []
+            for i, y in enumerate(ys):
+                name = "{}{}".format(h_prefix, _alpha_name(i, start_h_letter))
+                planned_h.append({"name": name, "y_mm": round(_ft_to_mm(y), 3)})
+
+            if dry_run:
+                return routes.make_response(data={
+                    "status": "dry_run",
+                    "walls_scanned": len(walls),
+                    "skipped_diagonal": skipped_diagonal,
+                    "skipped_curved": skipped_curved,
+                    "skipped_non_curve": skipped_non_curve,
+                    "would_create_vertical": planned_v,
+                    "would_create_horizontal": planned_h,
+                    "extent_mm": {
+                        "min_x": round(_ft_to_mm(min_x), 3),
+                        "max_x": round(_ft_to_mm(max_x), 3),
+                        "min_y": round(_ft_to_mm(min_y), 3),
+                        "max_y": round(_ft_to_mm(max_y), 3),
+                    },
+                })
+
+            # Check for name collisions with existing grids
+            existing_names = set()
+            for g in DB.FilteredElementCollector(doc).OfClass(DB.Grid):
+                try:
+                    existing_names.add(DB.Element.Name.__get__(g))
+                except Exception:
+                    pass
+
+            collisions = [p for p in (planned_v + planned_h) if p["name"] in existing_names]
+            if collisions:
+                return routes.make_response(data={
+                    "status": "name_collision",
+                    "error": "Grid name(s) already in use: {}. Choose different vertical_prefix / horizontal_prefix / start_* values, or delete the existing grids first.".format(
+                        ", ".join(p["name"] for p in collisions[:10])),
+                    "collisions": [p["name"] for p in collisions],
+                })
+
+            created_v = []
+            created_h = []
+            with DB.Transaction(doc, "MCP: Create grids from wall centerlines") as t:
+                t.Start()
+                for p in planned_v:
+                    x = _mm_to_feet(p["x_mm"])
+                    line = DB.Line.CreateBound(DB.XYZ(x, min_y, 0), DB.XYZ(x, max_y, 0))
+                    g = DB.Grid.Create(doc, line)
+                    g.Name = p["name"]
+                    created_v.append({
+                        "name": p["name"],
+                        "x_mm": p["x_mm"],
+                        "element_id": element_id_value(g.Id),
+                    })
+                for p in planned_h:
+                    y = _mm_to_feet(p["y_mm"])
+                    line = DB.Line.CreateBound(DB.XYZ(min_x, y, 0), DB.XYZ(max_x, y, 0))
+                    g = DB.Grid.Create(doc, line)
+                    g.Name = p["name"]
+                    created_h.append({
+                        "name": p["name"],
+                        "y_mm": p["y_mm"],
+                        "element_id": element_id_value(g.Id),
+                    })
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "document_title": normalize_string(doc.Title),
+                "walls_scanned": len(walls),
+                "skipped_diagonal": skipped_diagonal,
+                "skipped_curved": skipped_curved,
+                "vertical_count": len(created_v),
+                "horizontal_count": len(created_h),
+                "vertical_grids": created_v,
+                "horizontal_grids": created_h,
+                "extent_mm": {
+                    "min_x": round(_ft_to_mm(min_x), 3),
+                    "max_x": round(_ft_to_mm(max_x), 3),
+                    "min_y": round(_ft_to_mm(min_y), 3),
+                    "max_y": round(_ft_to_mm(max_y), 3),
+                },
+            })
+
+        except Exception as e:
+            logger.error("create_grids_from_walls failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Grids routes registered successfully")

--- a/revit_mcp/integration.py
+++ b/revit_mcp/integration.py
@@ -1,0 +1,230 @@
+# -*- coding: UTF-8 -*-
+"""
+Integration Module for Revit MCP
+Discover other pyRevit extensions installed on the system and invoke named
+functions from their lib/ directories.
+
+`use_module` is intentionally narrow: it imports the named module from the
+named extension's `lib/` directory and calls a named function. This is
+strictly more limited than `execute_revit_code` (no arbitrary statements,
+must be a function that already exists). Confirmation gate present anyway.
+"""
+
+from pyrevit import routes
+import os
+import json
+import importlib
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def _list_extensions():
+    """Discover pyRevit extensions on disk.
+
+    Returns a list of {name, path, type, has_lib, command_count} dicts.
+    Scans pyRevit's bundled extensions root plus all user-configured
+    custom-extension parent dirs.
+    """
+    try:
+        from pyrevit.userconfig import user_config
+        from pyrevit import EXTENSIONS_DEFAULT_DIR
+    except ImportError:
+        return []
+
+    roots = set()
+    try:
+        if EXTENSIONS_DEFAULT_DIR and os.path.exists(EXTENSIONS_DEFAULT_DIR):
+            roots.add(EXTENSIONS_DEFAULT_DIR)
+    except Exception:
+        pass
+    try:
+        for d in user_config.get_thirdparty_ext_root_dirs():
+            if os.path.exists(d):
+                roots.add(d)
+    except Exception:
+        pass
+
+    found = []
+    for root in roots:
+        try:
+            for name in os.listdir(root):
+                full = os.path.join(root, name)
+                if not os.path.isdir(full):
+                    continue
+                if name.endswith(".extension"):
+                    ext_type = "ui"
+                elif name.endswith(".lib"):
+                    ext_type = "lib"
+                else:
+                    continue
+                lib_path = os.path.join(full, "lib")
+                # Quick command count: walk for .pushbutton folders (UI extensions only)
+                cmd_count = 0
+                if ext_type == "ui":
+                    for dirpath, dirnames, _ in os.walk(full):
+                        for dn in dirnames:
+                            if dn.endswith(".pushbutton"):
+                                cmd_count += 1
+                found.append({
+                    "name": name,
+                    "path": full,
+                    "type": ext_type,
+                    "has_lib": os.path.isdir(lib_path),
+                    "command_count": cmd_count,
+                })
+        except Exception as e:
+            logger.warning("Could not scan extension root {}: {}".format(root, str(e)))
+    return found
+
+
+def register_integration_routes(api):
+    """Register module-discovery and module-invocation endpoints."""
+
+    @api.route("/search_modules/", methods=["GET", "POST"])
+    def search_modules(request):
+        """
+        List installed pyRevit extensions and (optionally) filter by query.
+
+        GET: returns all installed extensions.
+        POST payload: {"query": "tag"} — case-insensitive substring filter on name.
+        """
+        try:
+            data = _parse_json_request(request) if request else {}
+            query = (data.get("query") or "").strip().lower() if isinstance(data, dict) else ""
+
+            extensions = _list_extensions()
+            if query:
+                extensions = [e for e in extensions if query in e["name"].lower()]
+
+            return routes.make_response(data={
+                "status": "success",
+                "query": query or None,
+                "count": len(extensions),
+                "extensions": extensions,
+            })
+        except Exception as e:
+            logger.error("search_modules failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/use_module/", methods=["POST"])
+    def use_module(doc, request):
+        """
+        Import a named module from a named extension's lib/ directory and
+        call a named function. Stricter than `execute_revit_code` — the
+        callable must already exist; no arbitrary statements.
+
+        Expected payload:
+        {
+            "extension_name": "my-tools.extension",      // full folder name (with .extension or .lib suffix)
+            "module_path":    "submodule.helpers",       // dotted import path under <extension>/lib/
+            "function_name":  "do_thing",
+            "args":           [],                         // positional args (optional, must be JSON-serialisable)
+            "kwargs":         {},                         // keyword args (optional)
+            "confirm":        false                        // must be true to execute (gate)
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            ext_name = data.get("extension_name")
+            module_path = data.get("module_path")
+            function_name = data.get("function_name")
+            args = data.get("args") or []
+            kwargs = data.get("kwargs") or {}
+            confirm = bool(data.get("confirm", False))
+
+            for field, val in (("extension_name", ext_name), ("module_path", module_path), ("function_name", function_name)):
+                if not val:
+                    return routes.make_response(data={"error": "Missing required field: {}".format(field)}, status=400)
+
+            # Locate the extension folder
+            target = None
+            for ext in _list_extensions():
+                if ext["name"] == ext_name:
+                    target = ext
+                    break
+            if target is None:
+                return routes.make_response(data={"error": "Extension not found: {}".format(ext_name)}, status=404)
+            if not target["has_lib"]:
+                return routes.make_response(data={
+                    "error": "Extension '{}' has no lib/ directory; cannot use_module against it.".format(ext_name),
+                }, status=400)
+
+            lib_dir = os.path.join(target["path"], "lib")
+
+            if not confirm:
+                return routes.make_response(data={
+                    "status": "preview",
+                    "confirm_required": True,
+                    "would_invoke": {
+                        "extension": ext_name,
+                        "lib_dir": lib_dir,
+                        "module": module_path,
+                        "function": function_name,
+                        "args": args,
+                        "kwargs": kwargs,
+                    },
+                    "hint": "Re-call with confirm=true to actually invoke. Note: arbitrary Python runs in Revit context with full API access.",
+                })
+
+            # Inject lib_dir into sys.path, import, call
+            import sys
+            inserted = False
+            if lib_dir not in sys.path:
+                sys.path.insert(0, lib_dir)
+                inserted = True
+            try:
+                if module_path in sys.modules:
+                    # Force a fresh import so dev iteration on the called module takes effect
+                    mod = importlib.reload(sys.modules[module_path])
+                else:
+                    mod = importlib.import_module(module_path)
+
+                fn = getattr(mod, function_name, None)
+                if fn is None or not callable(fn):
+                    return routes.make_response(data={
+                        "error": "Function '{}' not found (or not callable) in module '{}'".format(function_name, module_path),
+                    }, status=404)
+
+                result = fn(*args, **kwargs)
+                # Best-effort JSON-safety on the result
+                try:
+                    json.dumps(result)
+                    safe_result = result
+                except (TypeError, ValueError):
+                    safe_result = unicode(result) if result is not None else None
+
+                return routes.make_response(data={
+                    "status": "success",
+                    "extension": ext_name,
+                    "module": module_path,
+                    "function": function_name,
+                    "result": safe_result,
+                })
+            finally:
+                if inserted:
+                    try:
+                        sys.path.remove(lib_dir)
+                    except ValueError:
+                        pass
+
+        except Exception as e:
+            logger.error("use_module failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Integration routes registered successfully")

--- a/revit_mcp/levels.py
+++ b/revit_mcp/levels.py
@@ -1,0 +1,144 @@
+# -*- coding: UTF-8 -*-
+"""
+Levels Module for Revit MCP
+Create a level + (optionally) matching FloorPlan and CeilingPlan views in one
+transaction so a single Ctrl+Z reverts the whole thing.
+
+Units: elevation is in MILLIMETRES on the API; converted internally to Revit's
+decimal feet via UnitUtils.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _mm_to_feet(value_mm):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _find_view_family_type(doc, family):
+    """Find the first ViewFamilyType of the given DB.ViewFamily. None if absent."""
+    for v in DB.FilteredElementCollector(doc).OfClass(DB.ViewFamilyType):
+        if v.ViewFamily == family:
+            return v
+    return None
+
+
+def register_levels_routes(api):
+    """Register level-creation routes."""
+
+    @api.route("/create_level/", methods=["POST"])
+    def create_level(doc, request):
+        """
+        Create a level at the given elevation, optionally with matching plan views.
+
+        Expected payload:
+        {
+            "name":               "Level 3",   # required, unique within project
+            "elevation_mm":       7500.0,      # required, MILLIMETRES
+            "create_floor_plan":  true,         # optional, default true
+            "create_ceiling_plan": false,      # optional, default false
+            "view_name":          null          # optional, defaults to level name
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            name = data.get("name")
+            elevation_mm = data.get("elevation_mm")
+            create_fp = bool(data.get("create_floor_plan", True))
+            create_cp = bool(data.get("create_ceiling_plan", False))
+            view_name = data.get("view_name") or name
+
+            if not name or not isinstance(name, str):
+                return routes.make_response(data={"error": "Missing required field: name (string)"}, status=400)
+            if elevation_mm is None:
+                return routes.make_response(data={"error": "Missing required field: elevation_mm (number, millimetres)"}, status=400)
+            try:
+                elevation_mm = float(elevation_mm)
+            except (TypeError, ValueError):
+                return routes.make_response(data={"error": "elevation_mm must be a number"}, status=400)
+
+            # Refuse to create a duplicate level by name
+            for lvl in DB.FilteredElementCollector(doc).OfClass(DB.Level):
+                if DB.Element.Name.__get__(lvl) == name:
+                    return routes.make_response(data={
+                        "status": "name_collision",
+                        "error": "A level named '{}' already exists (id={}).".format(
+                            name, element_id_value(lvl.Id)),
+                        "existing_level_id": element_id_value(lvl.Id),
+                    })
+
+            # Resolve view family types up front (cheaper to fail before opening the transaction)
+            vft_fp = _find_view_family_type(doc, DB.ViewFamily.FloorPlan) if create_fp else None
+            vft_cp = _find_view_family_type(doc, DB.ViewFamily.CeilingPlan) if create_cp else None
+            if create_fp and vft_fp is None:
+                return routes.make_response(data={
+                    "error": "No FloorPlan ViewFamilyType found in the project; cannot create floor plan view.",
+                })
+            if create_cp and vft_cp is None:
+                return routes.make_response(data={
+                    "error": "No CeilingPlan ViewFamilyType found in the project; cannot create ceiling plan view.",
+                })
+
+            new_level = None
+            floor_plan = None
+            ceiling_plan = None
+            with DB.Transaction(doc, "MCP: Create Level + Views") as t:
+                t.Start()
+                new_level = DB.Level.Create(doc, _mm_to_feet(elevation_mm))
+                new_level.Name = name
+                if create_fp:
+                    floor_plan = DB.ViewPlan.Create(doc, vft_fp.Id, new_level.Id)
+                    floor_plan.Name = view_name
+                if create_cp:
+                    ceiling_plan = DB.ViewPlan.Create(doc, vft_cp.Id, new_level.Id)
+                    # Ceiling plan share-names with the floor plan would collide;
+                    # suffix with " - Ceiling" when both views are created.
+                    ceiling_plan.Name = (view_name + " - Ceiling") if create_fp else view_name
+                t.Commit()
+
+            return routes.make_response(data={
+                "status": "success",
+                "level": {
+                    "id": element_id_value(new_level.Id),
+                    "name": normalize_string(name),
+                    "elevation_mm": elevation_mm,
+                    "elevation_ft": float(_mm_to_feet(elevation_mm)),
+                },
+                "floor_plan": (
+                    {"id": element_id_value(floor_plan.Id), "name": DB.Element.Name.__get__(floor_plan)}
+                    if floor_plan is not None else None
+                ),
+                "ceiling_plan": (
+                    {"id": element_id_value(ceiling_plan.Id), "name": DB.Element.Name.__get__(ceiling_plan)}
+                    if ceiling_plan is not None else None
+                ),
+            })
+
+        except Exception as e:
+            logger.error("create_level failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Levels routes registered successfully")

--- a/revit_mcp/material_quantities.py
+++ b/revit_mcp/material_quantities.py
@@ -1,0 +1,354 @@
+# -*- coding: UTF-8 -*-
+"""
+Material Quantities Module for Revit MCP
+Walk model elements and sum up material volumes / areas, grouped by material.
+
+This is a READ-ONLY data-extraction tool — no transactions. The output rolls
+up every element that carries each material (via Element.GetMaterialIds /
+GetMaterialVolume / GetMaterialArea) so you can answer "how much concrete is
+in the model?" or "what's the total brick area in walls + floors?" in a
+single call.
+
+Units: outputs are in m3 (`volume_m3`) and m2 (`area_m2`). Revit's internal
+units are ft3 / ft2; conversion is via UnitUtils.
+
+Ported from Sparx mcp-servers-for-revit's GetMaterialQuantitiesCommand
+(Apache-2.0 licensed C# source at commandset/Services/DataExtraction/
+GetMaterialQuantitiesEventHandler.cs) into our IronPython pyRevit Routes
+pattern.
+
+Differences from the C# source:
+- Output units are m3 / m2 (Sparx returned ft3 / ft2 verbatim).
+- Adds optional `element_ids` (restrict to a caller-supplied set) and
+  `view_id` (restrict to elements visible in a view) inputs; Sparx only had
+  category_filters + selectedElementsOnly.
+- Returns per-material `categories` list (every category the material was
+  found on) — useful for the "is this brick on walls only or also on
+  floors?" question. Sparx didn't expose this.
+- `include_zero_volume=False` by default drops Material entries that
+  contribute zero m3 (these are usually thin-paint or decorative
+  applications that GetMaterialIds(False) shouldn't include but
+  occasionally leak through).
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+FT3_TO_M3 = 0.0283168
+FT2_TO_M2 = 0.092903
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _ft3_to_m3(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.CubicMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_CUBIC_METERS)
+    except Exception:
+        return float(v) * FT3_TO_M3
+
+
+def _ft2_to_m2(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.SquareMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_SQUARE_METERS)
+    except Exception:
+        return float(v) * FT2_TO_M2
+
+
+def _safe_category_name(elem):
+    try:
+        cat = elem.Category
+        if cat is None:
+            return None
+        return normalize_string(cat.Name)
+    except Exception:
+        return None
+
+
+def _resolve_view(doc, view_id):
+    """Return (view, source) or (None, reason). view_id=None means no view filter."""
+    if view_id is None:
+        return None, "no_view_filter"
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return "ERROR", "view_id_must_be_int"
+    el = doc.GetElement(vid)
+    if el is None or not isinstance(el, DB.View):
+        return "ERROR", "view_id_not_found"
+    return el, "explicit_view_id"
+
+
+def _parse_category_filter(category_filter):
+    """
+    Convert a list of BuiltInCategory names (e.g. "OST_Walls") into a list of
+    enum members. Returns (enum_list, invalid_names). Unknown names are
+    collected for diagnostics; they don't fail the request.
+    """
+    if not category_filter:
+        return [], []
+    if not isinstance(category_filter, list):
+        return None, [str(category_filter)]
+    enums = []
+    invalid = []
+    for name in category_filter:
+        if not isinstance(name, (str, unicode)):
+            invalid.append(name)
+            continue
+        # Accept both "OST_Walls" and "Walls" forms; the former is the
+        # canonical BuiltInCategory enum member.
+        ename = name if name.startswith("OST_") else "OST_" + name
+        member = getattr(DB.BuiltInCategory, ename, None)
+        if member is None:
+            invalid.append(name)
+        else:
+            enums.append(member)
+    return enums, invalid
+
+
+def _collect_elements(doc, view, category_enums, element_ids):
+    """
+    Build the element set per the input filters. Returns (list[Element], picker_path, invalid_element_ids).
+
+    Precedence: explicit element_ids > view filter > whole model.
+    Category filter is layered on top of any of those.
+    """
+    invalid_ids = []
+    if element_ids:
+        elements = []
+        for eid in element_ids:
+            try:
+                el = doc.GetElement(DB.ElementId(Int64(int(eid))))
+            except Exception:
+                el = None
+            if el is None:
+                invalid_ids.append(eid)
+                continue
+            # Skip ElementType subclasses (analogous to WhereElementIsNotElementType)
+            if isinstance(el, DB.ElementType):
+                invalid_ids.append(eid)
+                continue
+            elements.append(el)
+        # Apply category filter in-process for the explicit-id path
+        if category_enums:
+            allowed = set(int(e) for e in category_enums)
+            kept = []
+            for el in elements:
+                cat = el.Category
+                if cat is None:
+                    continue
+                try:
+                    if int(cat.Id.IntegerValue if hasattr(cat.Id, "IntegerValue") else cat.Id.Value) in allowed:
+                        kept.append(el)
+                except Exception:
+                    continue
+            elements = kept
+        return elements, "explicit_element_ids", invalid_ids
+
+    if view is not None:
+        collector = DB.FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType()
+        picker_path = "view_visible_elements"
+    else:
+        collector = DB.FilteredElementCollector(doc).WhereElementIsNotElementType()
+        picker_path = "whole_model"
+
+    if category_enums:
+        try:
+            # ElementMulticategoryFilter wants a .NET List[BuiltInCategory]
+            from System.Collections.Generic import List as NetList
+            bic_list = NetList[DB.BuiltInCategory]()
+            for e in category_enums:
+                bic_list.Add(e)
+            collector = collector.WherePasses(DB.ElementMulticategoryFilter(bic_list))
+            picker_path = picker_path + "+category_filter"
+        except Exception as ex:
+            logger.warning("category filter failed, falling back to no-filter: %s", str(ex))
+
+    return list(collector), picker_path, invalid_ids
+
+
+def register_material_quantities_routes(api):
+    """Register material-quantity extraction routes."""
+
+    @api.route("/get_material_quantities/", methods=["POST"])
+    def get_material_quantities(doc, request):
+        """
+        Roll up material volumes and areas across the model (or a subset).
+
+        Expected payload (all fields optional):
+        {
+            "category_filter":     ["OST_Walls", "OST_Floors"],  # null = all categories
+            "element_ids":         [123, 456],                   # null = all elements
+            "view_id":             null,                          # only elements visible in this view
+            "include_zero_volume": false                          # include materials with 0 m3
+        }
+
+        Returns status='success' with a `materials` list rolled up by material,
+        plus a `totals` block. Returns status='no_elements_found' when the
+        filter set has no elements.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+
+            # ----- Parse inputs -----
+            category_filter_raw = data.get("category_filter")
+            element_ids_raw = data.get("element_ids") or []
+            if not isinstance(element_ids_raw, list):
+                return routes.make_response(data={
+                    "error": "element_ids must be a list of integers"
+                }, status=400)
+            include_zero_volume = bool(data.get("include_zero_volume", False))
+
+            # Resolve view (None = no view filter; "ERROR" = invalid view_id supplied)
+            view_or_err, view_source = _resolve_view(doc, data.get("view_id"))
+            if view_or_err == "ERROR":
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": view_source,
+                })
+            view = view_or_err  # None or a real View
+
+            category_enums, invalid_cats = _parse_category_filter(category_filter_raw)
+            if category_enums is None:
+                return routes.make_response(data={
+                    "error": "category_filter must be a list of BuiltInCategory names (e.g. ['OST_Walls'])"
+                }, status=400)
+
+            # ----- Build element set -----
+            elements, picker_path, invalid_ids = _collect_elements(doc, view, category_enums, element_ids_raw)
+
+            if not elements:
+                return routes.make_response(data={
+                    "status": "no_elements_found",
+                    "picker_path": picker_path,
+                    "view_source": view_source,
+                    "invalid_element_ids": invalid_ids,
+                    "invalid_category_names": invalid_cats,
+                })
+
+            # ----- Accumulate material quantities -----
+            # Key on material ElementId int value.
+            # Each entry holds: dict with name, class, volume_ft3, area_ft2,
+            # element_ids set, categories set.
+            mat_data = {}
+
+            for elem in elements:
+                try:
+                    material_ids = elem.GetMaterialIds(False)
+                except Exception:
+                    # Element type doesn't carry materials (e.g. annotation, view, etc.)
+                    continue
+
+                if material_ids is None:
+                    continue
+
+                elem_id_v = element_id_value(elem.Id)
+                elem_cat = _safe_category_name(elem)
+
+                for mat_id in material_ids:
+                    material = doc.GetElement(mat_id)
+                    if material is None or not isinstance(material, DB.Material):
+                        continue
+
+                    try:
+                        vol = float(elem.GetMaterialVolume(mat_id))
+                    except Exception:
+                        vol = 0.0
+                    try:
+                        area = float(elem.GetMaterialArea(mat_id, False))
+                    except Exception:
+                        area = 0.0
+
+                    mid_v = element_id_value(mat_id)
+                    entry = mat_data.get(mid_v)
+                    if entry is None:
+                        entry = {
+                            "material_id": mid_v,
+                            "material_name": normalize_string(material.Name),
+                            "material_class": normalize_string(material.MaterialClass) if material.MaterialClass else None,
+                            "volume_ft3": 0.0,
+                            "area_ft2": 0.0,
+                            "element_ids": set(),
+                            "categories": set(),
+                        }
+                        mat_data[mid_v] = entry
+
+                    entry["volume_ft3"] += vol
+                    entry["area_ft2"] += area
+                    entry["element_ids"].add(elem_id_v)
+                    if elem_cat:
+                        entry["categories"].add(elem_cat)
+
+            # ----- Project to output shape -----
+            materials_out = []
+            total_vol_ft3 = 0.0
+            total_area_ft2 = 0.0
+            total_element_id_set = set()
+
+            for entry in mat_data.values():
+                vol_m3 = _ft3_to_m3(entry["volume_ft3"])
+                area_m2 = _ft2_to_m2(entry["area_ft2"])
+
+                if not include_zero_volume and vol_m3 <= 0.0 and area_m2 <= 0.0:
+                    continue
+
+                materials_out.append({
+                    "material_id": entry["material_id"],
+                    "material_name": entry["material_name"],
+                    "material_class": entry["material_class"],
+                    "volume_m3": round(vol_m3, 4),
+                    "area_m2": round(area_m2, 4),
+                    "element_count": len(entry["element_ids"]),
+                    "categories": sorted(list(entry["categories"])),
+                })
+                total_vol_ft3 += entry["volume_ft3"]
+                total_area_ft2 += entry["area_ft2"]
+                total_element_id_set.update(entry["element_ids"])
+
+            # Sort by volume descending, then by area, then by name
+            materials_out.sort(key=lambda m: (-m["volume_m3"], -m["area_m2"], m["material_name"]))
+
+            return routes.make_response(data={
+                "status": "success",
+                "materials": materials_out,
+                "totals": {
+                    "material_count": len(materials_out),
+                    "volume_m3": round(_ft3_to_m3(total_vol_ft3), 4),
+                    "area_m2": round(_ft2_to_m2(total_area_ft2), 4),
+                    "element_count": len(total_element_id_set),
+                },
+                "picker_path": picker_path,
+                "view_source": view_source,
+                "view_name": normalize_string(view.Name) if view is not None else None,
+                "view_id": element_id_value(view.Id) if view is not None else None,
+                "elements_scanned": len(elements),
+                "invalid_element_ids": invalid_ids,
+                "invalid_category_names": invalid_cats,
+            })
+
+        except Exception as e:
+            logger.error("get_material_quantities failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Material quantities routes registered successfully")

--- a/revit_mcp/mep_dimensions.py
+++ b/revit_mcp/mep_dimensions.py
@@ -1,0 +1,761 @@
+# -*- coding: UTF-8 -*-
+"""
+MEP-to-Grid Dimensioning Module for Revit MCP
+
+Automatically dimensions MEP elements (ducts, cable trays, pipes) to the
+project grid system in a plan view, laid out with clean, even spacing.
+
+This is the "locate the services against the grid" workflow that an MEP
+drafter does by hand on a coordination drawing: for each grid axis, the
+position of every duct/pipe centerline is dimensioned relative to the grid
+lines that box it in.
+
+----------------------------------------------------------------------
+HOW IT WORKS
+----------------------------------------------------------------------
+1. MEP runs are classified by their run direction:
+     - an X-running (East-West) run is LOCATED by its Y coordinate, so it is
+       dimensioned against the HORIZONTAL grids -> a VERTICAL dimension string.
+     - a Y-running (North-South) run is located by its X coordinate, so it is
+       dimensioned against the VERTICAL grids -> a HORIZONTAL dimension string.
+     - a Z-running riser (a point in plan) is skipped.
+2. Witness references:
+     - Grid           -> DB.Reference(grid)
+     - MEP centerline -> DB.Reference(mep_element)
+   Revit resolves a plain element reference on a Grid to the grid line and on
+   an MEPCurve (Duct / Pipe / CableTray) to its centerline. A linear
+   `Document.Create.NewDimension(view, line, ReferenceArray)` call with N
+   references in coordinate order produces one continuous (N-1)-segment
+   dimension string -- exactly the MEP-coordination pattern.
+3. Layout:
+     - `string_style="continuous"` -> ONE continuous string per orientation
+       witnessing the chosen grids + every MEP centerline (recommended).
+     - `string_style="individual"` -> one 3-reference dimension per MEP run
+       (grid-below -> run -> grid-above), greedily lane-stacked to avoid
+       overlaps.
+     - The dimension line sits `offset_mm` clear of the dimensioned geometry;
+       stacked strings (individual mode) are `gap_mm` apart.
+
+----------------------------------------------------------------------
+REVIT 2026 IRONPYTHON NOTES (see CLAUDE.md)
+----------------------------------------------------------------------
+- ElementId integer read via the shared `element_id_value()` helper (.Value).
+- `DB.ElementId(System.Int64(id))` for any id constructed from an int literal.
+- `DB.Element.Name.__get__(elem)` for Grid / ElementType name reads.
+- `NewDimension` does NOT open independent sub-transactions, so a single
+  `DB.Transaction` (not a TransactionGroup) gives atomic single-Ctrl+Z undo.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+FT_TO_MM = 304.8
+MM_TO_FT = 1.0 / 304.8
+
+# MEP categories this tool can dimension. Keys are the friendly aliases the
+# tool accepts; values are the BuiltInCategory.
+MEP_CATEGORIES = {
+    "ducts": DB.BuiltInCategory.OST_DuctCurves,
+    "cable_trays": DB.BuiltInCategory.OST_CableTray,
+    "pipes": DB.BuiltInCategory.OST_PipeCurves,
+}
+# Alias normalisation so callers can pass "duct", "cabletray", "OST_PipeCurves", ...
+_CATEGORY_ALIASES = {
+    "duct": "ducts", "ducts": "ducts", "ductcurves": "ducts",
+    "ost_ductcurves": "ducts",
+    "cabletray": "cable_trays", "cabletrays": "cable_trays",
+    "cable_tray": "cable_trays", "cable_trays": "cable_trays",
+    "ost_cabletray": "cable_trays",
+    "pipe": "pipes", "pipes": "pipes", "pipecurves": "pipes",
+    "ost_pipecurves": "pipes",
+}
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def _mm_to_feet(value_mm):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _ft_to_mm(value_ft):
+    return value_ft * FT_TO_MM
+
+
+def _resolve_plan_view(doc, view_id):
+    """Return (view, source) or (None, reason). The view must be a ViewPlan."""
+    if view_id is not None:
+        try:
+            vid = DB.ElementId(Int64(int(view_id)))
+        except Exception:
+            return None, "view_id_must_be_int"
+        el = doc.GetElement(vid)
+        if el is None or not isinstance(el, DB.View):
+            return None, "view_id_not_found"
+        if not isinstance(el, DB.ViewPlan):
+            return None, "view_not_plan"
+        return el, "explicit_view_id"
+    try:
+        uidoc = revit.uidoc
+    except Exception:
+        uidoc = None
+    if uidoc is None or uidoc.ActiveView is None:
+        return None, "no_active_view"
+    av = uidoc.ActiveView
+    if not isinstance(av, DB.ViewPlan):
+        return None, "view_not_plan"
+    return av, "active_view"
+
+
+def _line_orientation(curve, tol_ft):
+    """Classify a DB.Line as 'x', 'y', 'z' or 'diagonal'.
+
+    'x' = runs mostly along X, 'y' = along Y, 'z' = vertical riser.
+    """
+    if not isinstance(curve, DB.Line):
+        return None
+    d = curve.Direction
+    ax, ay, az = abs(d.X), abs(d.Y), abs(d.Z)
+    if az > 0.7:
+        return "z"
+    if ax >= ay:
+        return "x" if ay < 0.34 else "diagonal"
+    return "y" if ax < 0.34 else "diagonal"
+
+
+def _classify_grid(grid):
+    """
+    Return (orientation, coord_ft) for an axis-aligned straight grid, or
+    (None, None) for arc / diagonal grids.
+
+    orientation 'vertical'   -> constant X line, coord = X
+    orientation 'horizontal' -> constant Y line, coord = Y
+    """
+    try:
+        curve = grid.Curve
+    except Exception:
+        return None, None
+    if not isinstance(curve, DB.Line):
+        return None, None
+    d = curve.Direction
+    p0 = curve.GetEndPoint(0)
+    if abs(d.X) < 1e-6 and abs(d.Y) > 1e-6:
+        return "vertical", p0.X
+    if abs(d.Y) < 1e-6 and abs(d.X) > 1e-6:
+        return "horizontal", p0.Y
+    return None, None
+
+
+def register_mep_dimensions_routes(api):
+    """Register the MEP-to-grid dimensioning route."""
+
+    @api.route("/dimension_mep_to_grids/", methods=["POST"])
+    def dimension_mep_to_grids(doc, request):
+        """
+        Dimension MEP elements (ducts / cable trays / pipes) to the project
+        grid system in a plan view.
+
+        Expected payload (all optional):
+        {
+            "view_id":                 null,     # plan view; default = active view
+            "element_ids":             [1,2,3],  # explicit MEP elements to dimension
+            "categories":              ["ducts","pipes","cable_trays"],
+            "string_style":            "continuous",  # or "individual"
+            "grid_scope":              "nearest",     # or "all"
+            "offset_mm":               2500.0,
+            "gap_mm":                  1200.0,
+            "coordinate_tolerance_mm": 10.0,
+            "max_elements":            200,
+            "dimension_style_id":      null,
+            "dry_run":                 false
+        }
+
+        When `element_ids` is omitted, every MEP element of the requested
+        categories that is visible in the view is dimensioned (subject to
+        `max_elements`).
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+
+            string_style = str(data.get("string_style", "continuous") or "continuous").lower()
+            if string_style not in ("continuous", "individual"):
+                return routes.make_response(data={
+                    "error": "string_style must be 'continuous' or 'individual'"}, status=400)
+            grid_scope = str(data.get("grid_scope", "nearest") or "nearest").lower()
+            if grid_scope not in ("nearest", "all"):
+                return routes.make_response(data={
+                    "error": "grid_scope must be 'nearest' or 'all'"}, status=400)
+
+            offset_mm = float(data.get("offset_mm", 2500.0))
+            gap_mm = float(data.get("gap_mm", 1200.0))
+            tol_mm = float(data.get("coordinate_tolerance_mm", 10.0))
+            max_elements = int(data.get("max_elements", 200))
+            dry_run = bool(data.get("dry_run", False))
+            dim_style_id = data.get("dimension_style_id")
+
+            offset_ft = _mm_to_feet(offset_mm)
+            gap_ft = _mm_to_feet(gap_mm)
+            tol_ft = _mm_to_feet(tol_mm)
+            end_margin_ft = _mm_to_feet(1000.0)
+
+            # ----- Resolve view -----
+            view, view_source = _resolve_plan_view(doc, data.get("view_id"))
+            if view is None:
+                return routes.make_response(data={
+                    "status": "view_not_found" if view_source != "view_not_plan" else "view_not_plan",
+                    "error": {
+                        "view_id_must_be_int": "view_id must be an integer",
+                        "view_id_not_found": "view_id does not resolve to a view",
+                        "view_not_plan": "Target view is not a plan view. MEP-to-grid "
+                                         "dimensioning needs a FloorPlan / CeilingPlan / "
+                                         "EngineeringPlan / AreaPlan.",
+                        "no_active_view": "No active view and no view_id supplied",
+                    }.get(view_source, view_source),
+                })
+
+            # ----- Which MEP categories -----
+            cats_raw = data.get("categories")
+            if cats_raw:
+                if not isinstance(cats_raw, list):
+                    return routes.make_response(data={
+                        "error": "categories must be a list of strings"}, status=400)
+                wanted = []
+                for c in cats_raw:
+                    key = _CATEGORY_ALIASES.get(str(c).strip().lower())
+                    if key and key not in wanted:
+                        wanted.append(key)
+                if not wanted:
+                    return routes.make_response(data={
+                        "error": "categories did not match any of: ducts, cable_trays, pipes"},
+                        status=400)
+            else:
+                wanted = ["ducts", "cable_trays", "pipes"]
+
+            # ----- Collect grids visible in the view -----
+            grid_v = []   # (coord_ft, grid)  vertical grids (constant X)
+            grid_h = []   # (coord_ft, grid)  horizontal grids (constant Y)
+            skipped_grids = 0
+            for g in DB.FilteredElementCollector(doc, view.Id).OfClass(DB.Grid):
+                orient, coord = _classify_grid(g)
+                if orient == "vertical":
+                    grid_v.append((coord, g))
+                elif orient == "horizontal":
+                    grid_h.append((coord, g))
+                else:
+                    skipped_grids += 1
+            grid_v.sort(key=lambda t: t[0])
+            grid_h.sort(key=lambda t: t[0])
+
+            if not grid_v and not grid_h:
+                return routes.make_response(data={
+                    "status": "no_grids",
+                    "error": "No axis-aligned grids are visible in view '{}'. "
+                             "Create a grid system first (see create_grids_from_walls).".format(
+                                 normalize_string(view.Name)),
+                    "skipped_non_axis_aligned_grids": skipped_grids,
+                    "view_name": normalize_string(view.Name),
+                    "view_id": element_id_value(view.Id),
+                })
+
+            # ----- Collect MEP elements -----
+            mep_elements = []
+            invalid_ids = []
+            wrong_category_ids = []
+            element_ids_raw = data.get("element_ids")
+            source_mode = None
+
+            if element_ids_raw:
+                source_mode = "element_ids"
+                if not isinstance(element_ids_raw, list):
+                    return routes.make_response(data={
+                        "error": "element_ids must be a list of integers"}, status=400)
+                for eid in element_ids_raw:
+                    try:
+                        el = doc.GetElement(DB.ElementId(Int64(int(eid))))
+                    except Exception:
+                        el = None
+                    if el is None:
+                        invalid_ids.append(eid)
+                        continue
+                    if not isinstance(el, DB.MEPCurve):
+                        wrong_category_ids.append(eid)
+                        continue
+                    mep_elements.append(el)
+            else:
+                source_mode = "view_visible"
+                for key in wanted:
+                    bic = MEP_CATEGORIES[key]
+                    for el in (DB.FilteredElementCollector(doc, view.Id)
+                               .OfCategory(bic).WhereElementIsNotElementType()):
+                        if isinstance(el, DB.MEPCurve):
+                            mep_elements.append(el)
+
+            if not mep_elements:
+                return routes.make_response(data={
+                    "status": "no_mep_elements",
+                    "error": "No dimensionable MEP elements found "
+                             "({}).".format("from the supplied element_ids"
+                                            if source_mode == "element_ids"
+                                            else "visible in the view"),
+                    "invalid_element_ids": invalid_ids,
+                    "wrong_category_element_ids": wrong_category_ids,
+                    "view_name": normalize_string(view.Name),
+                })
+
+            if source_mode == "view_visible" and len(mep_elements) > max_elements:
+                return routes.make_response(data={
+                    "status": "too_many_elements",
+                    "error": "{} MEP elements are visible in the view, which exceeds "
+                             "max_elements={}. Dimensioning that many at once would be "
+                             "unreadable. Pass an explicit element_ids list for the runs "
+                             "you want, narrow the view, or raise max_elements "
+                             "deliberately.".format(len(mep_elements), max_elements),
+                    "mep_visible_count": len(mep_elements),
+                    "max_elements": max_elements,
+                    "view_name": normalize_string(view.Name),
+                })
+
+            # ----- Classify each MEP element by run orientation -----
+            # x_runs: located by Y -> dimensioned against horizontal grids
+            # y_runs: located by X -> dimensioned against vertical grids
+            x_runs = []   # dict per run
+            y_runs = []
+            skipped_mep = []   # (id, reason)
+            for el in mep_elements:
+                loc = el.Location
+                if not isinstance(loc, DB.LocationCurve):
+                    skipped_mep.append((element_id_value(el.Id), "no_location_curve"))
+                    continue
+                curve = loc.Curve
+                orient = _line_orientation(curve, tol_ft)
+                if orient is None:
+                    skipped_mep.append((element_id_value(el.Id), "non_linear_curve"))
+                    continue
+                if orient == "z":
+                    skipped_mep.append((element_id_value(el.Id), "vertical_riser"))
+                    continue
+                if orient == "diagonal":
+                    skipped_mep.append((element_id_value(el.Id), "diagonal_run"))
+                    continue
+                p0 = curve.GetEndPoint(0)
+                p1 = curve.GetEndPoint(1)
+                try:
+                    cat_name = normalize_string(el.Category.Name)
+                except Exception:
+                    cat_name = None
+                run = {
+                    "element": el,
+                    "id": element_id_value(el.Id),
+                    "category": cat_name,
+                }
+                if orient == "x":
+                    run["coord"] = (p0.Y + p1.Y) / 2.0          # located by Y
+                    run["ext_min"] = min(p0.X, p1.X)
+                    run["ext_max"] = max(p0.X, p1.X)
+                    x_runs.append(run)
+                else:
+                    run["coord"] = (p0.X + p1.X) / 2.0          # located by X
+                    run["ext_min"] = min(p0.Y, p1.Y)
+                    run["ext_max"] = max(p0.Y, p1.Y)
+                    y_runs.append(run)
+
+            if not x_runs and not y_runs:
+                return routes.make_response(data={
+                    "status": "no_dimensionable_mep",
+                    "error": "MEP elements were found but none are axis-aligned "
+                             "horizontal runs. Risers and diagonal runs cannot be "
+                             "dimensioned to grids in plan.",
+                    "skipped_mep": [{"id": i, "reason": r} for i, r in skipped_mep],
+                    "view_name": normalize_string(view.Name),
+                })
+
+            # ----- Build the dimension plan for each orientation -----
+            # An orientation "job" pairs one MEP-run group with the grid list
+            # it is dimensioned against and the axis the string measures along.
+            jobs = []
+            if x_runs:
+                jobs.append({
+                    "name": "horizontal_runs_vs_horizontal_grids",
+                    "runs": x_runs,
+                    "grids": grid_h,
+                    "measure_axis": "y",   # string measures Y, runs vertically
+                })
+            if y_runs:
+                jobs.append({
+                    "name": "vertical_runs_vs_vertical_grids",
+                    "runs": y_runs,
+                    "grids": grid_v,
+                    "measure_axis": "x",   # string measures X, runs horizontally
+                })
+
+            planned = []   # one entry per dimension string we intend to create
+            warnings = []
+
+            for job in jobs:
+                runs = job["runs"]
+                grids = job["grids"]
+                if not grids:
+                    warnings.append(
+                        "{}: no grids of the required orientation are visible in "
+                        "the view; {} run(s) left undimensioned.".format(
+                            job["name"], len(runs)))
+                    for r in runs:
+                        skipped_mep.append((r["id"], "no_grids_for_orientation"))
+                    continue
+
+                grid_coords = [c for c, _ in grids]
+
+                # Dedupe MEP runs that share a coordinate (parallel segments of
+                # one visual run). Keep the first; record the rest.
+                runs_sorted = sorted(runs, key=lambda r: r["coord"])
+                mep_nodes = []
+                for r in runs_sorted:
+                    if mep_nodes and abs(r["coord"] - mep_nodes[-1]["coord"]) <= tol_ft:
+                        mep_nodes[-1]["merged_ids"].append(r["id"])
+                        continue
+                    mep_nodes.append({
+                        "coord": r["coord"],
+                        "element": r["element"],
+                        "id": r["id"],
+                        "category": r["category"],
+                        "ext_min": r["ext_min"],
+                        "ext_max": r["ext_max"],
+                        "merged_ids": [],
+                    })
+
+                # Which grids participate.
+                if grid_scope == "all":
+                    chosen_grid_idx = set(range(len(grids)))
+                else:
+                    chosen_grid_idx = set()
+                    for mn in mep_nodes:
+                        mc = mn["coord"]
+                        below = None
+                        above = None
+                        for gi, gc in enumerate(grid_coords):
+                            if gc <= mc + tol_ft:
+                                below = gi
+                            if gc >= mc - tol_ft and above is None:
+                                above = gi
+                        if below is not None:
+                            chosen_grid_idx.add(below)
+                        if above is not None:
+                            chosen_grid_idx.add(above)
+
+                grid_nodes = [{
+                    "coord": grids[gi][0],
+                    "element": grids[gi][1],
+                    "name": get_element_name(grids[gi][1]),
+                } for gi in sorted(chosen_grid_idx)]
+
+                # Combined, coordinate-sorted node list. When a MEP run sits on
+                # a grid (within tolerance) we keep the grid and drop the run.
+                combined = []
+                for gn in grid_nodes:
+                    combined.append(("grid", gn["coord"], gn))
+                for mn in mep_nodes:
+                    combined.append(("mep", mn["coord"], mn))
+                combined.sort(key=lambda t: t[1])
+
+                nodes = []
+                for kind, coord, payload in combined:
+                    if nodes and abs(coord - nodes[-1]["coord"]) <= tol_ft:
+                        prev = nodes[-1]
+                        if prev["kind"] == "mep" and kind == "grid":
+                            # Grid wins the slot; the run is on the grid line.
+                            skipped_mep.append((prev["payload"]["id"], "coincides_with_grid"))
+                            nodes[-1] = {"kind": kind, "coord": coord, "payload": payload}
+                        elif kind == "mep":
+                            skipped_mep.append((payload["id"], "coincides_with_grid"
+                                                if prev["kind"] == "grid"
+                                                else "duplicate_coordinate"))
+                        # grid-on-grid duplicate: keep the first, drop silently.
+                        continue
+                    nodes.append({"kind": kind, "coord": coord, "payload": payload})
+
+                mep_node_count = len([n for n in nodes if n["kind"] == "mep"])
+                if mep_node_count == 0:
+                    warnings.append(
+                        "{}: every run coincided with a grid line; nothing to "
+                        "dimension.".format(job["name"]))
+                    continue
+                if len(nodes) < 2:
+                    warnings.append(
+                        "{}: fewer than 2 distinct witness coordinates; cannot "
+                        "build a dimension.".format(job["name"]))
+                    continue
+
+                # Geometry extent of the dimensioned runs (for offset placement).
+                ext_lo = min(mn["ext_min"] for mn in mep_nodes)
+                ext_hi = max(mn["ext_max"] for mn in mep_nodes)
+                coord_lo = nodes[0]["coord"]
+                coord_hi = nodes[-1]["coord"]
+
+                job_plan = {
+                    "name": job["name"],
+                    "measure_axis": job["measure_axis"],
+                    "nodes": nodes,
+                    "ext_lo": ext_lo,
+                    "ext_hi": ext_hi,
+                    "coord_lo": coord_lo,
+                    "coord_hi": coord_hi,
+                    "strings": [],
+                }
+
+                # ---- Build the dimension string(s) for this job ----
+                if string_style == "continuous":
+                    job_plan["strings"].append({
+                        "node_indices": list(range(len(nodes))),
+                        "lane": 0,
+                    })
+                else:
+                    # Individual: one dim per MEP node = [grid_below, mep, grid_above]
+                    # Greedy lane stacking so overlapping spans don't collide.
+                    dims = []
+                    for i, n in enumerate(nodes):
+                        if n["kind"] != "mep":
+                            continue
+                        gb = None
+                        ga = None
+                        for j in range(i - 1, -1, -1):
+                            if nodes[j]["kind"] == "grid":
+                                gb = j
+                                break
+                        for j in range(i + 1, len(nodes)):
+                            if nodes[j]["kind"] == "grid":
+                                ga = j
+                                break
+                        idxs = [x for x in (gb, i, ga) if x is not None]
+                        if len(idxs) < 2:
+                            skipped_mep.append((n["payload"]["id"], "no_bracketing_grid"))
+                            continue
+                        dims.append({
+                            "node_indices": idxs,
+                            "span_lo": nodes[idxs[0]]["coord"],
+                            "span_hi": nodes[idxs[-1]]["coord"],
+                        })
+                    dims.sort(key=lambda d: d["span_lo"])
+                    lane_last_hi = []
+                    for d in dims:
+                        placed = False
+                        for lane in range(len(lane_last_hi)):
+                            if d["span_lo"] >= lane_last_hi[lane] - tol_ft:
+                                d["lane"] = lane
+                                lane_last_hi[lane] = d["span_hi"]
+                                placed = True
+                                break
+                        if not placed:
+                            d["lane"] = len(lane_last_hi)
+                            lane_last_hi.append(d["span_hi"])
+                        job_plan["strings"].append(d)
+
+                planned.append(job_plan)
+
+            if not planned:
+                return routes.make_response(data={
+                    "status": "nothing_created",
+                    "error": "No dimension strings could be planned. See warnings "
+                             "and skipped_mep for why.",
+                    "warnings": warnings,
+                    "skipped_mep": [{"id": i, "reason": r} for i, r in skipped_mep],
+                    "view_name": normalize_string(view.Name),
+                })
+
+            # ----- Resolve the dimension style (optional) -----
+            dim_type = None
+            if dim_style_id is not None:
+                try:
+                    dt = doc.GetElement(DB.ElementId(Int64(int(dim_style_id))))
+                    if isinstance(dt, DB.DimensionType):
+                        dim_type = dt
+                except Exception:
+                    dim_type = None
+
+            # ----- Compute the dimension-line geometry for every planned string -----
+            # measure_axis 'y' -> vertical string, placed at an X west of the runs.
+            # measure_axis 'x' -> horizontal string, placed at a Y south of the runs.
+            def _string_geometry(job_plan, lane):
+                axis = job_plan["measure_axis"]
+                c_lo = job_plan["coord_lo"] - end_margin_ft
+                c_hi = job_plan["coord_hi"] + end_margin_ft
+                if axis == "y":
+                    base = job_plan["ext_lo"] - offset_ft
+                    pos = base - lane * gap_ft
+                    p_start = DB.XYZ(pos, c_lo, 0.0)
+                    p_end = DB.XYZ(pos, c_hi, 0.0)
+                else:
+                    base = job_plan["ext_lo"] - offset_ft
+                    pos = base - lane * gap_ft
+                    p_start = DB.XYZ(c_lo, pos, 0.0)
+                    p_end = DB.XYZ(c_hi, pos, 0.0)
+                return DB.Line.CreateBound(p_start, p_end), pos
+
+            # ----- Dry run: report the plan without touching the model -----
+            if dry_run:
+                preview = []
+                for jp in planned:
+                    strings_preview = []
+                    for s in jp["strings"]:
+                        node_idx = s["node_indices"]
+                        _, pos = _string_geometry(jp, s["lane"])
+                        strings_preview.append({
+                            "lane": s["lane"],
+                            "reference_count": len(node_idx),
+                            "segments": len(node_idx) - 1,
+                            "witnesses": [
+                                {"kind": jp["nodes"][k]["kind"],
+                                 "coord_mm": round(_ft_to_mm(jp["nodes"][k]["coord"]), 1)}
+                                for k in node_idx],
+                            "dimension_line_position_mm": round(_ft_to_mm(pos), 1),
+                        })
+                    preview.append({
+                        "orientation": jp["name"],
+                        "string_count": len(strings_preview),
+                        "strings": strings_preview,
+                    })
+                return routes.make_response(data={
+                    "status": "dry_run",
+                    "string_style": string_style,
+                    "grid_scope": grid_scope,
+                    "view_name": normalize_string(view.Name),
+                    "view_id": element_id_value(view.Id),
+                    "planned": preview,
+                    "warnings": warnings,
+                    "skipped_mep": [{"id": i, "reason": r} for i, r in skipped_mep],
+                })
+
+            # ----- Create every dimension string in ONE transaction -----
+            created = []
+            create_errors = []
+            with DB.Transaction(doc, "MCP: Dimension MEP to grids") as t:
+                t.Start()
+                for jp in planned:
+                    nodes = jp["nodes"]
+                    for s in jp["strings"]:
+                        node_idx = s["node_indices"]
+                        ref_array = DB.ReferenceArray()
+                        for k in node_idx:
+                            try:
+                                ref_array.Append(DB.Reference(nodes[k]["payload"]["element"]))
+                            except Exception as ref_err:
+                                create_errors.append({
+                                    "orientation": jp["name"],
+                                    "error": "reference build failed: {}".format(ref_err),
+                                })
+                        if ref_array.Size < 2:
+                            create_errors.append({
+                                "orientation": jp["name"],
+                                "error": "fewer than 2 valid references for a string",
+                            })
+                            continue
+                        dim_line, pos = _string_geometry(jp, s["lane"])
+                        try:
+                            dim = doc.Create.NewDimension(view, dim_line, ref_array)
+                        except Exception as ce:
+                            create_errors.append({
+                                "orientation": jp["name"],
+                                "error": str(ce),
+                            })
+                            continue
+                        if dim is None:
+                            create_errors.append({
+                                "orientation": jp["name"],
+                                "error": "NewDimension returned None",
+                            })
+                            continue
+                        if dim_type is not None:
+                            try:
+                                dim.DimensionType = dim_type
+                            except Exception:
+                                pass
+                        # Read measured values.
+                        seg_values_mm = []
+                        try:
+                            n_seg = dim.NumberOfSegments
+                        except Exception:
+                            n_seg = 0
+                        try:
+                            if n_seg and n_seg > 1 and dim.Segments is not None:
+                                for seg in dim.Segments:
+                                    sv = seg.Value
+                                    seg_values_mm.append(
+                                        round(sv * FT_TO_MM, 1) if sv is not None else None)
+                            else:
+                                dv = dim.Value
+                                if dv is not None:
+                                    seg_values_mm.append(round(dv * FT_TO_MM, 1))
+                        except Exception:
+                            pass
+                        created.append({
+                            "orientation": jp["name"],
+                            "dimension_id": element_id_value(dim.Id),
+                            "lane": s["lane"],
+                            "reference_count": ref_array.Size,
+                            "segments": len(seg_values_mm),
+                            "segment_values_mm": seg_values_mm,
+                            "dimension_line_position_mm": round(_ft_to_mm(pos), 1),
+                        })
+                if created:
+                    t.Commit()
+                else:
+                    t.RollBack()
+
+            if not created:
+                return routes.make_response(data={
+                    "status": "create_failed",
+                    "error": "Revit refused every planned dimension string.",
+                    "create_errors": create_errors,
+                    "warnings": warnings,
+                    "skipped_mep": [{"id": i, "reason": r} for i, r in skipped_mep],
+                    "view_name": normalize_string(view.Name),
+                })
+
+            return routes.make_response(data={
+                "status": "success",
+                "string_style": string_style,
+                "grid_scope": grid_scope,
+                "view_name": normalize_string(view.Name),
+                "view_id": element_id_value(view.Id),
+                "source_mode": source_mode,
+                "dimensions_created": len(created),
+                "dimensions": created,
+                "grids_visible": {"vertical": len(grid_v), "horizontal": len(grid_h)},
+                "mep_input_count": len(mep_elements),
+                "mep_dimensioned": len(mep_elements) - len(skipped_mep),
+                "skipped_mep": [{"id": i, "reason": r} for i, r in skipped_mep],
+                "invalid_element_ids": invalid_ids,
+                "wrong_category_element_ids": wrong_category_ids,
+                "create_errors": create_errors,
+                "warnings": warnings,
+                "offset_mm": offset_mm,
+                "gap_mm": gap_mm,
+            })
+
+        except Exception as e:
+            logger.error("dimension_mep_to_grids failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("MEP dimensions routes registered successfully")

--- a/revit_mcp/model_statistics.py
+++ b/revit_mcp/model_statistics.py
@@ -1,0 +1,404 @@
+# -*- coding: UTF-8 -*-
+"""
+Model-Statistics Module for Revit MCP
+High-level rollup of what's in the project: element counts by category,
+type/family breakdowns inside each category, per-level element counts,
+and project-wide totals (elements / types / families / views / sheets).
+
+This is a READ-ONLY data-extraction tool — no transactions.
+
+Ported from Sparx mcp-servers-for-revit's AnalyzeModelStatistics command
+(Apache-2.0 licensed C# source at commandset/Services/DataExtraction/
+AnalyzeModelStatisticsEventHandler.cs) into our IronPython pyRevit Routes
+pattern.
+
+Differences from the C# source:
+- Adds optional filters: category_filter, view_id, top_n_categories,
+  top_n_types_per_category. Sparx scanned the entire model unconditionally.
+- Level elevations are reported in mm (Sparx returned raw decimal feet).
+- Uses the descriptor accessor (DB.Element.Name.__get__) via
+  get_element_name() for Revit 2026 IronPython ElementType safety; Sparx
+  used .Name directly which fails on Revit 2026.
+- Categories are sorted by element_count descending (matches Sparx) but
+  the per-category Types list is also sorted by instance_count descending
+  (Sparx returned in insertion order).
+- Adds `truncated_categories` and `truncated_types_per_category` diagnostic
+  flags when caps are applied.
+- Returns `applied_filters` list for diagnostics.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _ft_to_mm(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_MILLIMETERS)
+    except Exception:
+        return float(v) * 304.8
+
+
+def _resolve_view(doc, view_id):
+    """Return (view, source) or ("ERROR", reason). view_id=None means no view filter."""
+    if view_id is None:
+        return None, "no_view_filter"
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return "ERROR", "view_id_must_be_int"
+    el = doc.GetElement(vid)
+    if el is None or not isinstance(el, DB.View):
+        return "ERROR", "view_id_not_found"
+    return el, "explicit_view_id"
+
+
+def _parse_category_filter(category_filter):
+    """
+    Convert a list of BuiltInCategory names (e.g. "OST_Walls") into a list of
+    enum members. Returns (enum_list, invalid_names). Unknown names are
+    collected for diagnostics; they don't fail the request.
+    """
+    if not category_filter:
+        return [], []
+    if not isinstance(category_filter, list):
+        return None, [str(category_filter)]
+    enums = []
+    invalid = []
+    for name in category_filter:
+        if not isinstance(name, (str, unicode)):
+            invalid.append(name)
+            continue
+        ename = name if name.startswith("OST_") else "OST_" + name
+        member = getattr(DB.BuiltInCategory, ename, None)
+        if member is None:
+            invalid.append(name)
+        else:
+            enums.append(member)
+    return enums, invalid
+
+
+def _build_instance_collector(doc, view, category_enums):
+    """Element-instance collector with optional view + category filters."""
+    if view is not None:
+        collector = DB.FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType()
+    else:
+        collector = DB.FilteredElementCollector(doc).WhereElementIsNotElementType()
+
+    if category_enums:
+        try:
+            from System.Collections.Generic import List as NetList
+            bic_list = NetList[DB.BuiltInCategory]()
+            for e in category_enums:
+                bic_list.Add(e)
+            collector = collector.WherePasses(DB.ElementMulticategoryFilter(bic_list))
+        except Exception as ex:
+            logger.warning("category filter failed, returning unfiltered collector: %s", str(ex))
+    return collector
+
+
+def register_model_statistics_routes(api):
+    """Register model-statistics rollup routes."""
+
+    @api.route("/analyze_model_statistics/", methods=["POST"])
+    def analyze_model_statistics(doc, request):
+        """
+        Roll up project-level statistics: counts, categories, types, levels.
+
+        Expected payload (all fields optional):
+        {
+            "category_filter":            ["OST_Walls"],   // null = all categories
+            "view_id":                    null,             // restrict to view-visible
+            "include_detailed_types":     true,
+            "top_n_categories":           null,             // cap categories list
+            "top_n_types_per_category":   null              // cap types per category
+        }
+
+        Returns:
+            {
+              "status": "success",
+              "project_name": "Project1",
+              "totals": {
+                "elements": N, "types": N, "families": N,
+                "views": N, "sheets": N
+              },
+              "categories": [
+                {
+                  "category_name": "Walls",
+                  "element_count": N,
+                  "type_count": N,
+                  "family_count": N,
+                  "types": [{"type_name": ..., "family_name": ..., "instance_count": N}]
+                }
+              ],
+              "levels": [{"level_name": ..., "elevation_mm": ..., "element_count": N}],
+              "applied_filters": [...],
+              "view_source": ...,
+              "view_id": ..., "view_name": ...,
+              "invalid_category_names": [...],
+              "truncated_categories": false,
+              "truncated_types_per_category": false
+            }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            category_filter_raw = data.get("category_filter")
+            include_detailed_types = bool(data.get("include_detailed_types", True))
+            top_n_categories = data.get("top_n_categories")
+            top_n_types_per_category = data.get("top_n_types_per_category")
+
+            if top_n_categories is not None:
+                try:
+                    top_n_categories = int(top_n_categories)
+                    if top_n_categories <= 0:
+                        top_n_categories = None
+                except Exception:
+                    return routes.make_response(data={
+                        "error": "top_n_categories must be a positive integer"
+                    }, status=400)
+            if top_n_types_per_category is not None:
+                try:
+                    top_n_types_per_category = int(top_n_types_per_category)
+                    if top_n_types_per_category <= 0:
+                        top_n_types_per_category = None
+                except Exception:
+                    return routes.make_response(data={
+                        "error": "top_n_types_per_category must be a positive integer"
+                    }, status=400)
+
+            view_or_err, view_source = _resolve_view(doc, data.get("view_id"))
+            if view_or_err == "ERROR":
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": view_source,
+                })
+            view = view_or_err  # None or a real View
+
+            category_enums, invalid_cats = _parse_category_filter(category_filter_raw)
+            if category_enums is None:
+                return routes.make_response(data={
+                    "error": "category_filter must be a list of BuiltInCategory names (e.g. ['OST_Walls'])"
+                }, status=400)
+
+            applied_filters = []
+            if category_filter_raw:
+                applied_filters.append("category_filter")
+            if view is not None:
+                applied_filters.append("view_id")
+            if not include_detailed_types:
+                applied_filters.append("no_detailed_types")
+            if top_n_categories:
+                applied_filters.append("top_n_categories={}".format(top_n_categories))
+            if top_n_types_per_category:
+                applied_filters.append("top_n_types_per_category={}".format(top_n_types_per_category))
+
+            # ----- Project-wide totals -----
+            project_name = normalize_string(doc.Title)
+
+            # Note: TotalElements / TotalTypes / TotalViews / TotalSheets are
+            # project-wide counts (Sparx behaviour) — they are NOT scoped by
+            # category_filter or view_id, since the scope filters are meant
+            # to narrow the per-category drill-down, not the headline numbers.
+            total_elements = DB.FilteredElementCollector(doc) \
+                .WhereElementIsNotElementType().GetElementCount()
+            total_types = DB.FilteredElementCollector(doc) \
+                .WhereElementIsElementType().GetElementCount()
+            total_sheets = DB.FilteredElementCollector(doc).OfClass(DB.ViewSheet).GetElementCount()
+
+            # Views: exclude templates (matches Sparx)
+            total_views = 0
+            for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+                if v is None:
+                    continue
+                try:
+                    if not v.IsTemplate:
+                        total_views += 1
+                except Exception:
+                    total_views += 1
+
+            # ----- Category + type rollup (scoped by filters) -----
+            category_stats = {}    # cat_name -> dict
+            family_names = set()   # project-wide unique families (matches Sparx)
+
+            for elem in _build_instance_collector(doc, view, category_enums):
+                cat = elem.Category
+                if cat is None:
+                    continue
+                try:
+                    cat_name = normalize_string(cat.Name)
+                except Exception:
+                    continue
+
+                cs = category_stats.get(cat_name)
+                if cs is None:
+                    cs = {
+                        "category_name": cat_name,
+                        "element_count": 0,
+                        "types": {},   # (family_name, type_name) -> count
+                    }
+                    category_stats[cat_name] = cs
+
+                cs["element_count"] += 1
+
+                # FamilyInstance gets family/type info
+                if isinstance(elem, DB.FamilyInstance):
+                    try:
+                        symbol = elem.Symbol
+                    except Exception:
+                        symbol = None
+                    if symbol is not None:
+                        try:
+                            family_name = normalize_string(symbol.Family.Name) if symbol.Family else None
+                        except Exception:
+                            family_name = None
+                        try:
+                            type_name = normalize_string(get_element_name(symbol))
+                        except Exception:
+                            type_name = None
+
+                        if family_name:
+                            family_names.add(family_name)
+
+                        if include_detailed_types and type_name:
+                            key = (family_name or u"", type_name)
+                            cs["types"][key] = cs["types"].get(key, 0) + 1
+                else:
+                    # Non-FamilyInstance: still useful to know the wall/floor type
+                    # WallType / FloorType / CeilingType inherit ElementType.
+                    if include_detailed_types:
+                        try:
+                            tid = elem.GetTypeId()
+                        except Exception:
+                            tid = None
+                        if tid is not None and tid != DB.ElementId.InvalidElementId:
+                            type_el = doc.GetElement(tid)
+                            if type_el is not None:
+                                try:
+                                    type_name = normalize_string(get_element_name(type_el))
+                                except Exception:
+                                    type_name = None
+                                if type_name:
+                                    key = (u"", type_name)
+                                    cs["types"][key] = cs["types"].get(key, 0) + 1
+
+            # Project to output shape
+            categories_out = []
+            truncated_types_per_cat = False
+            for cs in category_stats.values():
+                type_entries = []
+                # types dict: (family_name, type_name) -> count
+                for (fname, tname), cnt in cs["types"].items():
+                    type_entries.append({
+                        "type_name": tname,
+                        "family_name": fname if fname else None,
+                        "instance_count": cnt,
+                    })
+                # Sort by instance_count desc, then type_name
+                type_entries.sort(key=lambda t: (-t["instance_count"], t["type_name"] or u""))
+
+                cap_applied = False
+                if top_n_types_per_category and len(type_entries) > top_n_types_per_category:
+                    type_entries = type_entries[:top_n_types_per_category]
+                    cap_applied = True
+                    truncated_types_per_cat = True
+
+                type_count = len(set(t["type_name"] for t in type_entries))
+                fam_count = len(set((t["family_name"] or u"") for t in type_entries
+                                    if t["family_name"]))
+
+                cat_out = {
+                    "category_name": cs["category_name"],
+                    "element_count": cs["element_count"],
+                    "type_count": type_count,
+                    "family_count": fam_count,
+                    "types": type_entries,
+                    "types_truncated": cap_applied,
+                }
+                categories_out.append(cat_out)
+
+            categories_out.sort(key=lambda c: (-c["element_count"], c["category_name"]))
+
+            truncated_categories = False
+            if top_n_categories and len(categories_out) > top_n_categories:
+                categories_out = categories_out[:top_n_categories]
+                truncated_categories = True
+
+            # ----- Per-level rollup -----
+            levels = list(DB.FilteredElementCollector(doc).OfClass(DB.Level))
+            # Sort by elevation asc (matches Sparx)
+            levels.sort(key=lambda l: l.Elevation)
+
+            level_stats = []
+            for lvl in levels:
+                lvl_id = lvl.Id
+                # Count instances at this level (project-wide; not scoped by
+                # category_filter / view, to give honest level-occupancy data)
+                try:
+                    lvl_count = DB.FilteredElementCollector(doc) \
+                        .WhereElementIsNotElementType() \
+                        .WherePasses(DB.ElementLevelFilter(lvl_id)) \
+                        .GetElementCount()
+                except Exception:
+                    # Fallback to manual iteration if ElementLevelFilter misbehaves
+                    lvl_count = 0
+                    for el in DB.FilteredElementCollector(doc).WhereElementIsNotElementType():
+                        try:
+                            if el.LevelId == lvl_id:
+                                lvl_count += 1
+                        except Exception:
+                            continue
+
+                level_stats.append({
+                    "level_id": element_id_value(lvl_id),
+                    "level_name": normalize_string(get_element_name(lvl)),
+                    "elevation_mm": round(_ft_to_mm(lvl.Elevation), 3),
+                    "element_count": lvl_count,
+                })
+
+            return routes.make_response(data={
+                "status": "success",
+                "project_name": project_name,
+                "totals": {
+                    "elements": total_elements,
+                    "types": total_types,
+                    "families": len(family_names),
+                    "views": total_views,
+                    "sheets": total_sheets,
+                },
+                "categories": categories_out,
+                "levels": level_stats,
+                "applied_filters": applied_filters,
+                "view_source": view_source,
+                "view_id": element_id_value(view.Id) if view is not None else None,
+                "view_name": normalize_string(get_element_name(view)) if view is not None else None,
+                "invalid_category_names": invalid_cats,
+                "truncated_categories": truncated_categories,
+                "truncated_types_per_category": truncated_types_per_cat,
+            })
+
+        except Exception as e:
+            logger.error("analyze_model_statistics failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Model-statistics routes registered successfully")

--- a/revit_mcp/room_annotation.py
+++ b/revit_mcp/room_annotation.py
@@ -1,0 +1,534 @@
+# -*- coding: UTF-8 -*-
+"""
+Room Tagging Module for Revit MCP
+Bulk-place RoomTag elements over placed rooms in a plan view.
+
+Single transaction (single Ctrl+Z reverts everything).
+
+Ported from Sparx mcp-servers-for-revit's TagRoomsEventHandler
+(Apache-2.0 licensed C# at commandset/Services/TagRoomsEventHandler.cs)
+into our IronPython pyRevit Routes pattern. This is the room equivalent
+of our existing `tag_walls` route.
+
+Differences from the Sparx C# source:
+- View switching is opt-in via `auto_switch_view` (default true). Sparx
+  swallowed the active view and silently switched when the view type or
+  level didn't match — surprising behavior. We tell the caller via
+  `view_switched=true` + `previous_view_name` in the response.
+- Adds explicit `view_id` to target a specific view without touching the
+  user's UI. When omitted, falls back to `uidoc.ActiveView`.
+- Skip categorization is reported as separate counters
+  (`skipped_existing` / `skipped_unplaced`) rather than Sparx's lumped
+  `skipped_rooms` list.
+- Each created tag location is reported in mm (Sparx returned both raw
+  feet and mm; mm is enough).
+- Revit 2026 safety: all `DB.ElementId(int_literal)` casts go via
+  `Int64(...)`; all `.Name` reads on tag-symbol FamilySymbols go via
+  `get_element_name()`. See feedback_revit_2026_elementid.md.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Plan view types that can host room tags. Sparx accepted FloorPlan +
+# CeilingPlan; AreaPlan and EngineeringPlan can also host RoomTags via
+# NewRoomTag so we accept them too.
+_PLAN_VIEW_TYPES = (
+    DB.ViewType.FloorPlan,
+    DB.ViewType.CeilingPlan,
+    DB.ViewType.AreaPlan,
+    DB.ViewType.EngineeringPlan,
+)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def _ft_to_mm(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_MILLIMETERS)
+    except Exception:
+        return float(v) * 304.8
+
+
+def _resolve_explicit_view(doc, view_id):
+    """Return (View|None, error_dict|None). view_id=None means caller didn't supply one."""
+    if view_id is None:
+        return None, None
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return None, {"status": "view_not_found", "error": "view_id must be int"}
+    el = doc.GetElement(vid)
+    if el is None or not isinstance(el, DB.View):
+        return None, {"status": "view_not_found", "error": "view_id_not_found"}
+    return el, None
+
+
+def _is_plan_view(view):
+    try:
+        return view.ViewType in _PLAN_VIEW_TYPES
+    except Exception:
+        return False
+
+
+def _find_first_floor_plan_for_level(doc, level_id):
+    """Find a non-template FloorPlan view bound to this level. Returns view or None."""
+    for v in DB.FilteredElementCollector(doc).OfClass(DB.ViewPlan):
+        try:
+            if v.IsTemplate:
+                continue
+            if v.ViewType != DB.ViewType.FloorPlan:
+                continue
+            gen = v.GenLevel
+            if gen is not None and gen.Id == level_id:
+                return v
+        except Exception:
+            continue
+    return None
+
+
+def _find_room_tag_symbol(doc, tag_type_id, tag_family_name, tag_type_name):
+    """
+    Pick a RoomTag FamilySymbol. Precedence:
+    1) Explicit tag_type_id (Int64-cast) if it resolves to a RoomTag FamilySymbol.
+    2) tag_family_name + tag_type_name match.
+    3) First available RoomTag FamilySymbol.
+
+    Returns (symbol|None, available_list).
+    """
+    available = []
+    chosen = None
+
+    # Path 1: explicit type id
+    if tag_type_id is not None:
+        try:
+            tid = DB.ElementId(Int64(int(tag_type_id)))
+            el = doc.GetElement(tid)
+            if el is not None and isinstance(el, DB.FamilySymbol):
+                cat = el.Category
+                if cat is not None:
+                    cat_id_val = element_id_value(cat.Id)
+                    if cat_id_val == int(DB.BuiltInCategory.OST_RoomTags):
+                        chosen = el
+        except Exception:
+            pass
+
+    # Path 2+3: walk all RoomTag FamilySymbols (for the available list and name match)
+    for sym in (DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_RoomTags)
+                .WhereElementIsElementType()):
+        if not isinstance(sym, DB.FamilySymbol):
+            continue
+        try:
+            fam_name = sym.Family.Name if sym.Family else u"?"
+        except Exception:
+            fam_name = u"?"
+        try:
+            sym_name = get_element_name(sym)
+        except Exception:
+            sym_name = u"?"
+        available.append({
+            "id": element_id_value(sym.Id),
+            "family": normalize_string(fam_name),
+            "type": normalize_string(sym_name),
+        })
+
+        if chosen is None and tag_family_name and tag_type_name:
+            if fam_name == tag_family_name and sym_name == tag_type_name:
+                chosen = sym
+        elif chosen is None and tag_family_name and not tag_type_name:
+            if fam_name == tag_family_name:
+                chosen = sym
+        elif chosen is None and not tag_family_name and tag_type_name:
+            if sym_name == tag_type_name:
+                chosen = sym
+        elif chosen is None and not tag_family_name and not tag_type_name:
+            chosen = sym  # first available wins
+
+    return chosen, available
+
+
+class _SuppressRoomNumberWarnings(object):
+    """
+    pyRevit/IronPython port of Sparx's TagRoomFailurePreprocessor —
+    silently deletes duplicate-room-number warnings raised during tag
+    placement so the transaction commits cleanly. Implements
+    IFailuresPreprocessor via duck typing (pyRevit's Routes API exposes
+    it that way).
+    """
+    def PreprocessFailures(self, failuresAccessor):
+        try:
+            failures = failuresAccessor.GetFailureMessages()
+            for f in failures:
+                try:
+                    desc = f.GetDescriptionText() or u""
+                    low = desc.lower()
+                    if "number" in low or "duplicate" in low:
+                        failuresAccessor.DeleteWarning(f)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return DB.FailureProcessingResult.Continue
+
+
+def register_room_annotation_routes(api):
+    """Register room-tagging endpoints."""
+
+    @api.route("/tag_rooms/", methods=["POST"])
+    def tag_rooms(doc, request):
+        """
+        Bulk-place RoomTag elements over rooms in a plan view.
+
+        Expected payload (all optional):
+        {
+            "room_ids":         [123, 456],          // null = all rooms visible in target view
+            "tag_family_name":  "Room Tag",          // null = first match
+            "tag_type_name":    "Standard",          // null = first match within family
+            "tag_type_id":      null,                // explicit FamilySymbol id; overrides name lookup
+            "leader":           false,
+            "view_id":          null,                // null = use uidoc.ActiveView
+            "auto_switch_view": true                 // if active/given view isn't a plan view
+                                                     // on the rooms' level, switch to a matching FP
+        }
+
+        Skip rules:
+            - room.Area <= 0 (unplaced)        -> counted in `skipped_unplaced`
+            - room already has tag in view     -> counted in `skipped_existing`
+
+        Returns:
+            { status, view_id, view_name, view_switched, previous_view_name,
+              tag_family, tag_type, total_rooms, tagged_count,
+              skipped_existing, skipped_unplaced, tags: [...up to 100...],
+              errors: [...] }
+
+        Status values:
+            - 'success'                — at least the transaction completed
+            - 'view_not_supported'     — view isn't a plan view and auto_switch_view=false
+            - 'no_room_tag_family'     — project has no RoomTag FamilySymbol
+            - 'view_not_found'         — explicit view_id was invalid
+            - 'no_rooms_in_view'       — view-scoped scan returned 0 rooms
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            room_ids_raw = data.get("room_ids") or []
+            if not isinstance(room_ids_raw, list):
+                return routes.make_response(data={
+                    "error": "room_ids must be a list of integers"
+                }, status=400)
+
+            tag_family_name = data.get("tag_family_name")
+            tag_type_name = data.get("tag_type_name")
+            tag_type_id = data.get("tag_type_id")
+            with_leader = bool(data.get("leader", False))
+            auto_switch_view = bool(data.get("auto_switch_view", True))
+
+            # ----- Resolve starting view -----
+            view, view_err = _resolve_explicit_view(doc, data.get("view_id"))
+            if view_err is not None:
+                return routes.make_response(data=view_err)
+
+            uidoc = revit.uidoc
+            if view is None:
+                if uidoc is None:
+                    return routes.make_response(data={
+                        "error": "No active Revit UI document and no view_id supplied"
+                    }, status=503)
+                view = uidoc.ActiveView
+
+            if view is None:
+                return routes.make_response(data={
+                    "status": "view_not_supported",
+                    "error": "No target view (active view is null and no view_id supplied)",
+                })
+
+            previous_view_name = normalize_string(view.Name)
+            view_switched = False
+
+            # ----- Resolve target level from rooms (for view-switch decisioning) -----
+            target_level_id = None
+            if room_ids_raw:
+                # Use the first valid room's level
+                for rid in room_ids_raw:
+                    try:
+                        el = doc.GetElement(DB.ElementId(Int64(int(rid))))
+                    except Exception:
+                        continue
+                    if isinstance(el, DB.Architecture.Room):
+                        try:
+                            target_level_id = el.LevelId
+                        except Exception:
+                            pass
+                        break
+            else:
+                # Any placed room in the project (Sparx pattern)
+                for r in (DB.FilteredElementCollector(doc)
+                          .OfCategory(DB.BuiltInCategory.OST_Rooms)
+                          .WhereElementIsNotElementType()):
+                    if not isinstance(r, DB.Architecture.Room):
+                        continue
+                    try:
+                        if r.Area > 0:
+                            target_level_id = r.LevelId
+                            break
+                    except Exception:
+                        continue
+
+            # ----- View-type / level check -----
+            is_plan = _is_plan_view(view)
+            level_ok = True
+            if is_plan and target_level_id is not None:
+                try:
+                    gen = view.GenLevel if isinstance(view, DB.ViewPlan) else None
+                    level_ok = (gen is not None and gen.Id == target_level_id)
+                except Exception:
+                    level_ok = False
+
+            needs_switch = (not is_plan) or (not level_ok)
+            if needs_switch:
+                if not auto_switch_view:
+                    return routes.make_response(data={
+                        "status": "view_not_supported",
+                        "view_id": element_id_value(view.Id),
+                        "view_name": previous_view_name,
+                        "view_type": str(view.ViewType),
+                        "needs_level_id": element_id_value(target_level_id) if target_level_id is not None else None,
+                        "error": "Active view isn't a plan view bound to the rooms' level, and auto_switch_view=False",
+                    })
+                if target_level_id is None:
+                    return routes.make_response(data={
+                        "status": "view_not_supported",
+                        "view_id": element_id_value(view.Id),
+                        "view_name": previous_view_name,
+                        "view_type": str(view.ViewType),
+                        "error": "No rooms found in the project, so we can't pick a target plan view automatically",
+                    })
+                new_view = _find_first_floor_plan_for_level(doc, target_level_id)
+                if new_view is None:
+                    return routes.make_response(data={
+                        "status": "view_not_supported",
+                        "view_id": element_id_value(view.Id),
+                        "view_name": previous_view_name,
+                        "view_type": str(view.ViewType),
+                        "needs_level_id": element_id_value(target_level_id),
+                        "error": "No matching FloorPlan view bound to the rooms' level was found",
+                    })
+                if uidoc is not None:
+                    try:
+                        uidoc.ActiveView = new_view
+                    except Exception:
+                        # Non-fatal: still tag in new_view even if we couldn't focus it
+                        pass
+                view = new_view
+                view_switched = True
+
+            # ----- Find a RoomTag FamilySymbol -----
+            chosen_symbol, available = _find_room_tag_symbol(
+                doc, tag_type_id, tag_family_name, tag_type_name
+            )
+            if chosen_symbol is None:
+                return routes.make_response(data={
+                    "status": "no_room_tag_family",
+                    "view_id": element_id_value(view.Id),
+                    "view_name": normalize_string(view.Name),
+                    "view_switched": view_switched,
+                    "previous_view_name": previous_view_name if view_switched else None,
+                    "available": available,
+                    "error": "No RoomTag FamilySymbol in this project. Load a Room Tag family and retry.",
+                })
+
+            # ----- Build room set -----
+            if room_ids_raw:
+                rooms = []
+                invalid_ids = []
+                for rid in room_ids_raw:
+                    try:
+                        el = doc.GetElement(DB.ElementId(Int64(int(rid))))
+                    except Exception:
+                        invalid_ids.append(rid)
+                        continue
+                    if el is None or not isinstance(el, DB.Architecture.Room):
+                        invalid_ids.append(rid)
+                        continue
+                    rooms.append(el)
+            else:
+                invalid_ids = []
+                rooms = list(DB.FilteredElementCollector(doc, view.Id)
+                             .OfCategory(DB.BuiltInCategory.OST_Rooms)
+                             .WhereElementIsNotElementType())
+
+            if not rooms:
+                return routes.make_response(data={
+                    "status": "no_rooms_in_view",
+                    "view_id": element_id_value(view.Id),
+                    "view_name": normalize_string(view.Name),
+                    "view_switched": view_switched,
+                    "previous_view_name": previous_view_name if view_switched else None,
+                    "invalid_room_ids": invalid_ids,
+                })
+
+            # ----- Existing-tag set: skip rooms that already have a tag in this view -----
+            rooms_with_tags = set()
+            for tag in (DB.FilteredElementCollector(doc, view.Id)
+                        .OfCategory(DB.BuiltInCategory.OST_RoomTags)
+                        .WhereElementIsNotElementType()):
+                if not isinstance(tag, DB.Architecture.RoomTag):
+                    continue
+                try:
+                    r = tag.Room
+                    if r is not None:
+                        rooms_with_tags.add(element_id_value(r.Id))
+                except Exception:
+                    continue
+
+            # ----- Tag placement loop -----
+            placed = []
+            errors = []
+            skipped_existing = 0
+            skipped_unplaced = 0
+
+            with DB.Transaction(doc, "MCP: Tag Rooms") as t:
+                # Suppress duplicate-number warnings (Sparx pattern)
+                try:
+                    fho = t.GetFailureHandlingOptions()
+                    fho.SetFailuresPreprocessor(_SuppressRoomNumberWarnings())
+                    fho.SetClearAfterRollback(True)
+                    fho.SetDelayedMiniWarnings(False)
+                    t.SetFailureHandlingOptions(fho)
+                except Exception as fh_err:
+                    logger.warning("Could not install failure preprocessor: %s", str(fh_err))
+
+                t.Start()
+                if not chosen_symbol.IsActive:
+                    chosen_symbol.Activate()
+                    doc.Regenerate()
+
+                for room in rooms:
+                    if not isinstance(room, DB.Architecture.Room):
+                        continue
+                    try:
+                        if room.Area <= 0:
+                            skipped_unplaced += 1
+                            continue
+                        room_id_v = element_id_value(room.Id)
+                        if room_id_v in rooms_with_tags:
+                            skipped_existing += 1
+                            continue
+
+                        # Pick tag insertion point — prefer LocationPoint, fall back to bbox centre
+                        loc = room.Location
+                        if isinstance(loc, DB.LocationPoint) and loc.Point is not None:
+                            center = loc.Point
+                        else:
+                            bbox = room.get_BoundingBox(view)
+                            if bbox is None:
+                                errors.append({
+                                    "room_id": room_id_v,
+                                    "error": "No LocationPoint and no bounding box in view",
+                                })
+                                continue
+                            center = DB.XYZ(
+                                (bbox.Min.X + bbox.Max.X) / 2.0,
+                                (bbox.Min.Y + bbox.Max.Y) / 2.0,
+                                (bbox.Min.Z + bbox.Max.Z) / 2.0,
+                            )
+
+                        tag_uv = DB.UV(center.X, center.Y)
+                        link_id = DB.LinkElementId(room.Id)
+                        tag = doc.Create.NewRoomTag(link_id, tag_uv, view.Id)
+                        if tag is None:
+                            errors.append({
+                                "room_id": room_id_v,
+                                "error": "NewRoomTag returned null",
+                            })
+                            continue
+
+                        if with_leader:
+                            try:
+                                tag.HasLeader = True
+                            except Exception:
+                                pass
+
+                        # Capture room name + number for response
+                        try:
+                            rn_param = room.get_Parameter(DB.BuiltInParameter.ROOM_NAME)
+                            room_name = rn_param.AsString() if rn_param is not None else None
+                        except Exception:
+                            room_name = None
+                        try:
+                            room_number = room.Number
+                        except Exception:
+                            room_number = None
+
+                        placed.append({
+                            "tag_id": element_id_value(tag.Id),
+                            "room_id": room_id_v,
+                            "room_name": normalize_string(room_name) if room_name else None,
+                            "room_number": normalize_string(room_number) if room_number else None,
+                            "location_mm": {
+                                "x": round(_ft_to_mm(center.X), 3),
+                                "y": round(_ft_to_mm(center.Y), 3),
+                                "z": round(_ft_to_mm(center.Z), 3),
+                            },
+                        })
+                    except Exception as room_err:
+                        errors.append({
+                            "room_id": element_id_value(room.Id) if room is not None else None,
+                            "error": str(room_err),
+                        })
+                        continue
+
+                t.Commit()
+
+            # Truncate tags response to keep payloads sane
+            TAG_CAP = 100
+            tags_truncated = len(placed) > TAG_CAP
+
+            return routes.make_response(data={
+                "status": "success",
+                "view_id": element_id_value(view.Id),
+                "view_name": normalize_string(view.Name),
+                "view_switched": view_switched,
+                "previous_view_name": previous_view_name if view_switched else None,
+                "tag_family": normalize_string(chosen_symbol.Family.Name) if chosen_symbol.Family else None,
+                "tag_type": normalize_string(get_element_name(chosen_symbol)),
+                "tag_type_id": element_id_value(chosen_symbol.Id),
+                "total_rooms": len(rooms),
+                "tagged_count": len(placed),
+                "skipped_existing": skipped_existing,
+                "skipped_unplaced": skipped_unplaced,
+                "tags": placed[:TAG_CAP],
+                "tags_truncated": tags_truncated,
+                "errors": errors,
+                "invalid_room_ids": invalid_ids,
+            })
+
+        except Exception as e:
+            logger.error("tag_rooms failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Room-annotation routes registered successfully")

--- a/revit_mcp/room_data.py
+++ b/revit_mcp/room_data.py
@@ -1,0 +1,514 @@
+# -*- coding: UTF-8 -*-
+"""
+Room Data Export Module for Revit MCP
+Read-only export of every Room element in the project (or a filtered subset)
+with full parameter set: name, number, level, phase, area, volume, perimeter,
+height, location, bounding box, department, occupancy, comments.
+
+This is a READ-ONLY data-extraction tool — no transactions.
+
+Ported from Sparx mcp-servers-for-revit's ExportRoomDataEventHandler
+(Apache-2.0 licensed C# at commandset/Services/DataExtraction/
+ExportRoomDataEventHandler.cs) into our IronPython pyRevit Routes pattern.
+
+Differences from the Sparx C# source:
+- Output units: area in m² (`area_m2`), volume in m³ (`volume_m3`),
+  perimeter in mm (`perimeter_mm`), height in mm (`unbounded_height_mm`).
+  Sparx returned raw decimal feet/ft²/ft³ verbatim.
+- Adds optional filters: level_id, level_name, view_id, phase_id, room_ids.
+- Properly separates "unplaced" (no LocationPoint) from "not enclosed"
+  (has LocationPoint but Area==0). Sparx's two flags were identical bugs
+  — they both checked `Area == 0` with no way to distinguish.
+- Adds per-room `location_mm` and `bounding_box_mm` to support downstream
+  coordinate-based operations (e.g. piping the output into tag_rooms or
+  create_dimension).
+- Returns `applied_filters` diagnostic + per-status invalid-id lists
+  (invalid_room_ids / level_not_found / phase_not_found).
+- Revit 2026 safety: Int64-cast ElementIds; get_element_name() for Level
+  + Phase + ElementType name reads.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+from System import Int64
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data or {}
+
+
+def _ft_to_mm(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_MILLIMETERS)
+    except Exception:
+        return float(v) * 304.8
+
+
+def _ft2_to_m2(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.SquareMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_SQUARE_METERS)
+    except Exception:
+        return float(v) * 0.092903
+
+
+def _ft3_to_m3(v):
+    try:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.UnitTypeId.CubicMeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertFromInternalUnits(float(v), DB.DisplayUnitType.DUT_CUBIC_METERS)
+    except Exception:
+        return float(v) * 0.0283168
+
+
+def _safe_get_string_param(elem, bip):
+    try:
+        p = elem.get_Parameter(bip)
+        if p is None:
+            return None
+        s = p.AsString()
+        return s if s else None
+    except Exception:
+        return None
+
+
+def _safe_get_elementid_param(elem, bip):
+    try:
+        p = elem.get_Parameter(bip)
+        if p is None:
+            return None
+        eid = p.AsElementId()
+        if eid is None or eid == DB.ElementId.InvalidElementId:
+            return None
+        return eid
+    except Exception:
+        return None
+
+
+def _resolve_level(doc, level_id, level_name):
+    """Return (Level|None, error_string|None). All-None args means no level filter."""
+    if level_id is None and not level_name:
+        return None, None
+
+    if level_id is not None:
+        try:
+            lid = DB.ElementId(Int64(int(level_id)))
+        except Exception:
+            return None, "level_id_must_be_int"
+        el = doc.GetElement(lid)
+        if el is None or not isinstance(el, DB.Level):
+            return None, "level_id_not_found"
+        return el, None
+
+    # level_name path
+    for lvl in DB.FilteredElementCollector(doc).OfClass(DB.Level):
+        try:
+            if get_element_name(lvl) == level_name:
+                return lvl, None
+        except Exception:
+            continue
+    return None, "level_name_not_found"
+
+
+def _resolve_phase(doc, phase_id):
+    if phase_id is None:
+        return None, None
+    try:
+        pid = DB.ElementId(Int64(int(phase_id)))
+    except Exception:
+        return None, "phase_id_must_be_int"
+    el = doc.GetElement(pid)
+    if el is None or not isinstance(el, DB.Phase):
+        return None, "phase_id_not_found"
+    return el, None
+
+
+def _resolve_view(doc, view_id):
+    if view_id is None:
+        return None, None
+    try:
+        vid = DB.ElementId(Int64(int(view_id)))
+    except Exception:
+        return None, "view_id_must_be_int"
+    el = doc.GetElement(vid)
+    if el is None or not isinstance(el, DB.View):
+        return None, "view_id_not_found"
+    return el, None
+
+
+def _classify_room_placement(room):
+    """
+    Return one of: 'placed', 'unplaced', 'not_enclosed'.
+
+    - 'unplaced':     room.Location is None (Revit's "Not Placed" schedule bucket)
+    - 'not_enclosed': room has a Location but Area==0 (room exists at a point
+                      but the bounding curves don't form a closed loop)
+    - 'placed':       Area > 0
+    """
+    try:
+        if room.Location is None:
+            return "unplaced"
+    except Exception:
+        return "unplaced"
+    try:
+        if room.Area <= 0:
+            return "not_enclosed"
+    except Exception:
+        return "not_enclosed"
+    return "placed"
+
+
+def _build_room_record(doc, room, view_for_bbox):
+    """Turn a Room into a JSON-serialisable dict with mm-normalised geometry."""
+    placement = _classify_room_placement(room)
+
+    rec = {
+        "id": element_id_value(room.Id),
+        "unique_id": normalize_string(room.UniqueId) if hasattr(room, "UniqueId") else None,
+        "name": None,
+        "number": None,
+        "placement": placement,
+        "level_id": None,
+        "level_name": None,
+        "phase_id": None,
+        "phase_name": None,
+        "area_m2": 0.0,
+        "volume_m3": 0.0,
+        "perimeter_mm": 0.0,
+        "unbounded_height_mm": 0.0,
+        "department": None,
+        "occupancy": None,
+        "comments": None,
+        "location_mm": None,
+        "bounding_box_mm": None,
+    }
+
+    # Name + number
+    rec["name"] = normalize_string(
+        _safe_get_string_param(room, DB.BuiltInParameter.ROOM_NAME) or u""
+    ) or None
+    try:
+        rec["number"] = normalize_string(room.Number) if room.Number else None
+    except Exception:
+        pass
+
+    # Level
+    try:
+        lvl = room.Level
+    except Exception:
+        lvl = None
+    if lvl is not None:
+        rec["level_id"] = element_id_value(lvl.Id)
+        try:
+            rec["level_name"] = normalize_string(get_element_name(lvl))
+        except Exception:
+            pass
+
+    # Phase
+    phase_eid = _safe_get_elementid_param(room, DB.BuiltInParameter.ROOM_PHASE)
+    if phase_eid is not None:
+        phase = doc.GetElement(phase_eid)
+        if phase is not None:
+            rec["phase_id"] = element_id_value(phase_eid)
+            try:
+                rec["phase_name"] = normalize_string(get_element_name(phase))
+            except Exception:
+                pass
+
+    # Numeric geometry (in ft / ft² / ft³ internally → convert)
+    try:
+        rec["area_m2"] = round(_ft2_to_m2(float(room.Area)), 4)
+    except Exception:
+        pass
+    try:
+        rec["volume_m3"] = round(_ft3_to_m3(float(room.Volume)), 4)
+    except Exception:
+        pass
+    try:
+        rec["perimeter_mm"] = round(_ft_to_mm(float(room.Perimeter)), 3)
+    except Exception:
+        pass
+    try:
+        rec["unbounded_height_mm"] = round(_ft_to_mm(float(room.UnboundedHeight)), 3)
+    except Exception:
+        pass
+
+    # Free-text params
+    rec["department"] = normalize_string(
+        _safe_get_string_param(room, DB.BuiltInParameter.ROOM_DEPARTMENT) or u""
+    ) or None
+    rec["occupancy"] = normalize_string(
+        _safe_get_string_param(room, DB.BuiltInParameter.ROOM_OCCUPANCY) or u""
+    ) or None
+    rec["comments"] = normalize_string(
+        _safe_get_string_param(room, DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS) or u""
+    ) or None
+
+    # Location point
+    try:
+        loc = room.Location
+        if isinstance(loc, DB.LocationPoint) and loc.Point is not None:
+            p = loc.Point
+            rec["location_mm"] = {
+                "x": round(_ft_to_mm(p.X), 3),
+                "y": round(_ft_to_mm(p.Y), 3),
+                "z": round(_ft_to_mm(p.Z), 3),
+            }
+    except Exception:
+        pass
+
+    # Bounding box (model space if no view supplied; otherwise view-clipped)
+    try:
+        bbox = room.get_BoundingBox(view_for_bbox)
+        if bbox is not None and bbox.Min is not None and bbox.Max is not None:
+            rec["bounding_box_mm"] = {
+                "min": {
+                    "x": round(_ft_to_mm(bbox.Min.X), 3),
+                    "y": round(_ft_to_mm(bbox.Min.Y), 3),
+                    "z": round(_ft_to_mm(bbox.Min.Z), 3),
+                },
+                "max": {
+                    "x": round(_ft_to_mm(bbox.Max.X), 3),
+                    "y": round(_ft_to_mm(bbox.Max.Y), 3),
+                    "z": round(_ft_to_mm(bbox.Max.Z), 3),
+                },
+            }
+    except Exception:
+        pass
+
+    return rec
+
+
+def register_room_data_routes(api):
+    """Register room-data extraction routes."""
+
+    @api.route("/export_room_data/", methods=["POST"])
+    def export_room_data(doc, request):
+        """
+        Export every Room in the project (or a filtered subset) as JSON.
+
+        Expected payload (all fields optional):
+        {
+            "room_ids":            [123, 456],     // explicit set, supersedes filters
+            "level_id":            null,
+            "level_name":          "Level 1",      // alternate to level_id
+            "view_id":             null,            // restrict to visible-in-view
+            "phase_id":            null,
+            "include_unplaced":    false,           // rooms with Location==None
+            "include_not_enclosed":false,           // rooms with Location but Area==0
+            "sort_by":             "number"         // "number" | "name" | "level" | "area"
+                                                    // default = "number"
+        }
+
+        Returns status='success' with `rooms` list (each carrying the full
+        parameter set) + a `totals` block. Each room is classified as
+        'placed' / 'unplaced' / 'not_enclosed' via the `placement` field.
+
+        Status values:
+            - 'success'             — at least the filter was valid
+            - 'no_rooms_found'      — filter produced an empty set
+            - 'level_not_found'     — explicit level_id/level_name invalid
+            - 'phase_not_found'     — explicit phase_id invalid
+            - 'view_not_found'      — explicit view_id invalid
+
+        No transactions — pure read.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            room_ids_raw = data.get("room_ids") or []
+            if not isinstance(room_ids_raw, list):
+                return routes.make_response(data={
+                    "error": "room_ids must be a list of integers"
+                }, status=400)
+
+            include_unplaced = bool(data.get("include_unplaced", False))
+            include_not_enclosed = bool(data.get("include_not_enclosed", False))
+            sort_by = (data.get("sort_by") or "number").lower()
+            if sort_by not in ("number", "name", "level", "area"):
+                return routes.make_response(data={
+                    "error": "sort_by must be one of: number, name, level, area"
+                }, status=400)
+
+            # Resolve scope filters
+            level, level_err = _resolve_level(doc, data.get("level_id"), data.get("level_name"))
+            if level_err is not None:
+                return routes.make_response(data={
+                    "status": "level_not_found",
+                    "error": level_err,
+                })
+            phase, phase_err = _resolve_phase(doc, data.get("phase_id"))
+            if phase_err is not None:
+                return routes.make_response(data={
+                    "status": "phase_not_found",
+                    "error": phase_err,
+                })
+            view, view_err = _resolve_view(doc, data.get("view_id"))
+            if view_err is not None:
+                return routes.make_response(data={
+                    "status": "view_not_found",
+                    "error": view_err,
+                })
+
+            applied_filters = []
+            if room_ids_raw:
+                applied_filters.append("room_ids")
+            if level is not None:
+                applied_filters.append("level_id" if data.get("level_id") is not None else "level_name")
+            if phase is not None:
+                applied_filters.append("phase_id")
+            if view is not None:
+                applied_filters.append("view_id")
+            if include_unplaced:
+                applied_filters.append("include_unplaced")
+            if include_not_enclosed:
+                applied_filters.append("include_not_enclosed")
+
+            # ----- Build room set -----
+            invalid_ids = []
+            if room_ids_raw:
+                rooms_in = []
+                for rid in room_ids_raw:
+                    try:
+                        el = doc.GetElement(DB.ElementId(Int64(int(rid))))
+                    except Exception:
+                        invalid_ids.append(rid)
+                        continue
+                    if el is None or not isinstance(el, DB.Architecture.Room):
+                        invalid_ids.append(rid)
+                        continue
+                    rooms_in.append(el)
+            else:
+                if view is not None:
+                    collector = DB.FilteredElementCollector(doc, view.Id)
+                else:
+                    collector = DB.FilteredElementCollector(doc)
+                collector = collector.OfCategory(DB.BuiltInCategory.OST_Rooms) \
+                    .WhereElementIsNotElementType()
+                rooms_in = [r for r in collector if isinstance(r, DB.Architecture.Room)]
+
+            # ----- Per-room filtering + record build -----
+            kept = []
+            skipped_unplaced = 0
+            skipped_not_enclosed = 0
+            skipped_other_level = 0
+            skipped_other_phase = 0
+
+            for room in rooms_in:
+                placement = _classify_room_placement(room)
+                if placement == "unplaced" and not include_unplaced:
+                    skipped_unplaced += 1
+                    continue
+                if placement == "not_enclosed" and not include_not_enclosed:
+                    skipped_not_enclosed += 1
+                    continue
+
+                if level is not None:
+                    try:
+                        lvl_id = room.LevelId
+                    except Exception:
+                        lvl_id = None
+                    if lvl_id is None or lvl_id != level.Id:
+                        skipped_other_level += 1
+                        continue
+
+                if phase is not None:
+                    phase_eid = _safe_get_elementid_param(room, DB.BuiltInParameter.ROOM_PHASE)
+                    if phase_eid is None or phase_eid != phase.Id:
+                        skipped_other_phase += 1
+                        continue
+
+                rec = _build_room_record(doc, room, view)
+                kept.append(rec)
+
+            if not kept:
+                return routes.make_response(data={
+                    "status": "no_rooms_found",
+                    "applied_filters": applied_filters,
+                    "skipped_unplaced": skipped_unplaced,
+                    "skipped_not_enclosed": skipped_not_enclosed,
+                    "skipped_other_level": skipped_other_level,
+                    "skipped_other_phase": skipped_other_phase,
+                    "invalid_room_ids": invalid_ids,
+                    "level_filter": normalize_string(get_element_name(level)) if level else None,
+                    "phase_filter": normalize_string(get_element_name(phase)) if phase else None,
+                    "view_filter": normalize_string(view.Name) if view else None,
+                })
+
+            # ----- Sort -----
+            def _natural_number_sort_key(s):
+                # "101A" sorts before "101B" and after "101"; numeric prefix is primary key.
+                if s is None:
+                    return (1, 0, u"")
+                s = s or u""
+                # Walk numeric prefix
+                i = 0
+                while i < len(s) and s[i].isdigit():
+                    i += 1
+                num_part = int(s[:i]) if i > 0 else 10**9  # rooms without numeric prefix sort last
+                return (0 if i > 0 else 1, num_part, s[i:].lower())
+
+            if sort_by == "number":
+                kept.sort(key=lambda r: _natural_number_sort_key(r.get("number")))
+            elif sort_by == "name":
+                kept.sort(key=lambda r: (r.get("name") or u"").lower())
+            elif sort_by == "level":
+                kept.sort(key=lambda r: (
+                    (r.get("level_name") or u"~").lower(),
+                    _natural_number_sort_key(r.get("number")),
+                ))
+            elif sort_by == "area":
+                kept.sort(key=lambda r: -float(r.get("area_m2") or 0.0))
+
+            # ----- Totals -----
+            total_area_m2 = sum(float(r.get("area_m2") or 0.0) for r in kept)
+            total_volume_m3 = sum(float(r.get("volume_m3") or 0.0) for r in kept)
+
+            return routes.make_response(data={
+                "status": "success",
+                "rooms": kept,
+                "totals": {
+                    "room_count": len(kept),
+                    "area_m2": round(total_area_m2, 4),
+                    "volume_m3": round(total_volume_m3, 4),
+                    "placed_count": sum(1 for r in kept if r["placement"] == "placed"),
+                    "unplaced_count": sum(1 for r in kept if r["placement"] == "unplaced"),
+                    "not_enclosed_count": sum(1 for r in kept if r["placement"] == "not_enclosed"),
+                },
+                "applied_filters": applied_filters,
+                "skipped_unplaced": skipped_unplaced,
+                "skipped_not_enclosed": skipped_not_enclosed,
+                "skipped_other_level": skipped_other_level,
+                "skipped_other_phase": skipped_other_phase,
+                "invalid_room_ids": invalid_ids,
+                "level_filter": normalize_string(get_element_name(level)) if level else None,
+                "phase_filter": normalize_string(get_element_name(phase)) if phase else None,
+                "view_filter": normalize_string(view.Name) if view else None,
+                "sort_by": sort_by,
+            })
+
+        except Exception as e:
+            logger.error("export_room_data failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Room-data routes registered successfully")

--- a/revit_mcp/rooms.py
+++ b/revit_mcp/rooms.py
@@ -1,0 +1,354 @@
+# -*- coding: UTF-8 -*-
+"""
+Rooms Module for Revit MCP
+Create a Room element at a 2D point on a level. The point must lie inside an
+area enclosed by room-bounding elements (walls, room separators) — otherwise
+Revit refuses to create the room and we return status='not_in_enclosed_area'.
+
+Units: x/y/offsets are in MILLIMETRES on the API; converted internally to
+Revit's decimal feet via UnitUtils.
+
+Ported from Sparx mcp-servers-for-revit's CreateRoomCommand (Apache-2.0
+licensed C# source at commandset/Services/Architecture/CreateRoomEventHandler.cs)
+into our IronPython pyRevit Routes pattern. Single-room creation only in v1;
+batch can be added later if a real workflow demands it.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+FT_TO_MM = 304.8
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _mm_to_feet(value_mm):
+    try:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.UnitTypeId.Millimeters)
+    except AttributeError:
+        return DB.UnitUtils.ConvertToInternalUnits(float(value_mm), DB.DisplayUnitType.DUT_MILLIMETERS)
+
+
+def _resolve_level(doc, level_id=None, elevation_mm=None):
+    """
+    Pick the target level. Priority:
+      1. Explicit level_id (must exist)
+      2. Nearest level to given elevation_mm
+      3. Lowest-elevation level in the project (fallback)
+
+    Returns (Level, reason_string) or (None, error_message).
+    """
+    if level_id is not None:
+        try:
+            lid = DB.ElementId(int(level_id))
+        except Exception:
+            return None, "level_id must be an integer"
+        el = doc.GetElement(lid)
+        if el is None or not isinstance(el, DB.Level):
+            return None, "level_id {} not found or not a Level".format(level_id)
+        return el, "explicit_level_id"
+
+    levels = list(DB.FilteredElementCollector(doc).OfClass(DB.Level))
+    if not levels:
+        return None, "no_levels"
+
+    if elevation_mm is not None:
+        try:
+            target_ft = _mm_to_feet(float(elevation_mm))
+        except (TypeError, ValueError):
+            return None, "elevation_mm must be a number"
+        nearest = None
+        best_dist = None
+        for lv in levels:
+            d = abs(lv.Elevation - target_ft)
+            if best_dist is None or d < best_dist:
+                best_dist = d
+                nearest = lv
+        return nearest, "nearest_to_elevation"
+
+    levels.sort(key=lambda l: l.Elevation)
+    return levels[0], "fallback_lowest_level"
+
+
+def _collect_existing_room_numbers(doc):
+    """Return a set of strings of every existing room number in the project."""
+    out = set()
+    for r in DB.FilteredElementCollector(doc) \
+                .OfCategory(DB.BuiltInCategory.OST_Rooms) \
+                .WhereElementIsNotElementType():
+        try:
+            n = r.Number
+            if n:
+                out.add(n)
+        except Exception:
+            continue
+    return out
+
+
+def _next_available_number(existing):
+    """Smallest positive integer-string not in `existing`. Handles legacy 'Room 101' style by
+    extracting trailing digits and incrementing past the max."""
+    max_num = 0
+    for s in existing:
+        # Try whole-string parse first
+        try:
+            v = int(s)
+            if v > max_num:
+                max_num = v
+            continue
+        except ValueError:
+            pass
+        # Trailing-digits fallback
+        tail = []
+        for ch in reversed(s):
+            if ch.isdigit():
+                tail.append(ch)
+            elif tail:
+                break
+        if tail:
+            try:
+                v = int("".join(reversed(tail)))
+                if v > max_num:
+                    max_num = v
+            except ValueError:
+                pass
+    candidate = max_num + 1
+    for _ in range(10000):
+        c = str(candidate)
+        if c not in existing:
+            return c
+        candidate += 1
+    return str(max_num + 1)
+
+
+def _unique_number_from(requested, existing):
+    """Return a unique number; if `requested` is taken, increment the trailing numeric portion
+    until free. Falls back to suffix letters A-Z, then -2,-3,... if needed."""
+    if not requested:
+        return _next_available_number(existing)
+    if requested not in existing:
+        return requested
+
+    # Extract last numeric run for incrementing
+    last_end = -1
+    last_start = -1
+    for i in range(len(requested) - 1, -1, -1):
+        if requested[i].isdigit():
+            if last_end == -1:
+                last_end = i
+            last_start = i
+        elif last_end != -1:
+            break
+    if last_start != -1:
+        prefix = requested[:last_start]
+        numpart = requested[last_start:last_end + 1]
+        suffix = requested[last_end + 1:]
+        try:
+            n = int(numpart)
+            width = len(numpart)
+            for i in range(1, 1001):
+                cand = prefix + str(n + i).rjust(width, "0") + suffix
+                if cand not in existing:
+                    return cand
+        except ValueError:
+            pass
+
+    for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+        cand = requested + c
+        if cand not in existing:
+            return cand
+    for i in range(2, 1001):
+        cand = "{}-{}".format(requested, i)
+        if cand not in existing:
+            return cand
+    return requested  # last resort
+
+
+def _set_string_param(elem, bip, value):
+    """Set a BuiltInParameter string if non-empty and writable. No-op otherwise."""
+    if not value:
+        return
+    p = elem.get_Parameter(bip)
+    if p is not None and not p.IsReadOnly:
+        try:
+            p.Set(value)
+        except Exception:
+            pass
+
+
+def _set_double_param_mm(elem, bip, value_mm):
+    """Set a BuiltInParameter double (Revit's internal feet) from a mm input."""
+    if value_mm is None:
+        return
+    p = elem.get_Parameter(bip)
+    if p is not None and not p.IsReadOnly:
+        try:
+            p.Set(_mm_to_feet(value_mm))
+        except Exception:
+            pass
+
+
+def _set_elemid_param(elem, bip, value_id):
+    """Set a BuiltInParameter ElementId from an integer."""
+    if value_id is None:
+        return
+    p = elem.get_Parameter(bip)
+    if p is not None and not p.IsReadOnly:
+        try:
+            p.Set(DB.ElementId(int(value_id)))
+        except Exception:
+            pass
+
+
+def register_rooms_routes(api):
+    """Register room-creation routes."""
+
+    @api.route("/create_room/", methods=["POST"])
+    def create_room(doc, request):
+        """
+        Create a Room element at a 2D point.
+
+        Expected payload (all coordinates / offsets in MILLIMETRES):
+        {
+            "x_mm":            -10000.0,   # required, location X
+            "y_mm":             -5000.0,   # required, location Y
+            "level_id":         311,       # optional, explicit Level element id
+            "elevation_mm":     null,      # optional, alternative to level_id (uses nearest Level)
+            "name":             "Office",  # optional, default "Room"
+            "number":           "101",     # optional, auto-generated or deduped if collides
+            "upper_limit_id":   null,      # optional, Level ElementId for upper limit
+            "limit_offset_mm":  null,      # optional, offset above upper limit
+            "base_offset_mm":   0,         # optional, offset above base level
+            "department":       null,      # optional
+            "comments":         null       # optional
+        }
+
+        If both level_id and elevation_mm are omitted, the lowest-elevation
+        level in the project is used.
+
+        Returns status='success' with the created room metadata, OR
+        status='not_in_enclosed_area' if the point isn't inside walls/separators.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+
+            # Required fields
+            if "x_mm" not in data or "y_mm" not in data:
+                return routes.make_response(data={
+                    "error": "Missing required field(s): x_mm and y_mm (numbers, millimetres)"
+                }, status=400)
+            try:
+                x_mm = float(data["x_mm"])
+                y_mm = float(data["y_mm"])
+            except (TypeError, ValueError):
+                return routes.make_response(data={
+                    "error": "x_mm and y_mm must be numbers"
+                }, status=400)
+
+            # Resolve level
+            level, level_reason = _resolve_level(
+                doc,
+                level_id=data.get("level_id"),
+                elevation_mm=data.get("elevation_mm"),
+            )
+            if level is None:
+                return routes.make_response(data={
+                    "status": "level_not_found" if level_reason != "no_levels" else "no_levels",
+                    "error": level_reason,
+                })
+
+            # Prep name + number deduplication BEFORE the transaction so we
+            # don't trigger Revit's duplicate-number warning dialog.
+            name = data.get("name") or "Room"
+            requested_number = data.get("number")
+            existing_numbers = _collect_existing_room_numbers(doc)
+            assigned_number = _unique_number_from(requested_number, existing_numbers)
+
+            x_ft = _mm_to_feet(x_mm)
+            y_ft = _mm_to_feet(y_mm)
+            uv = DB.UV(x_ft, y_ft)
+
+            room = None
+            with DB.Transaction(doc, "MCP: Create Room") as t:
+                t.Start()
+                try:
+                    room = doc.Create.NewRoom(level, uv)
+                except Exception as create_err:
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "create_failed",
+                        "error": str(create_err),
+                        "level_name": normalize_string(level.Name),
+                        "level_id": element_id_value(level.Id),
+                    })
+
+                if room is None:
+                    # Revit returns None when the point isn't inside an enclosed area
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "not_in_enclosed_area",
+                        "error": "The point ({:.1f}, {:.1f}) is not inside a room-bounded area on level '{}'. "
+                                 "Make sure walls or room separators fully enclose the location.".format(
+                                     x_mm, y_mm, normalize_string(level.Name)),
+                        "level_name": normalize_string(level.Name),
+                        "level_id": element_id_value(level.Id),
+                    })
+
+                # Set the name + number first (must be done before any other parameter
+                # to ensure unique number takes effect before Revit auto-validates).
+                _set_string_param(room, DB.BuiltInParameter.ROOM_NAME, name)
+                _set_string_param(room, DB.BuiltInParameter.ROOM_NUMBER, assigned_number)
+                _set_elemid_param(room, DB.BuiltInParameter.ROOM_UPPER_LEVEL, data.get("upper_limit_id"))
+                _set_double_param_mm(room, DB.BuiltInParameter.ROOM_UPPER_OFFSET, data.get("limit_offset_mm"))
+                _set_double_param_mm(room, DB.BuiltInParameter.ROOM_LOWER_OFFSET, data.get("base_offset_mm"))
+                _set_string_param(room, DB.BuiltInParameter.ROOM_DEPARTMENT, data.get("department"))
+                _set_string_param(room, DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS, data.get("comments"))
+
+                t.Commit()
+
+            # Revit stores Area in ft² internally; expose m² for human use
+            area_ft2 = float(room.Area)
+            area_m2 = area_ft2 * 0.092903   # 1 ft² = 0.092903 m²
+            perimeter_ft = float(room.Perimeter)
+            perimeter_m = perimeter_ft * 0.3048
+
+            return routes.make_response(data={
+                "status": "success",
+                "level_resolution": level_reason,
+                "room": {
+                    "id": element_id_value(room.Id),
+                    "unique_id": room.UniqueId,
+                    "name": normalize_string(name),
+                    "number": assigned_number,
+                    "requested_number": requested_number,
+                    "level_name": normalize_string(level.Name),
+                    "level_id": element_id_value(level.Id),
+                    "area_m2": round(area_m2, 3),
+                    "area_ft2": round(area_ft2, 3),
+                    "perimeter_m": round(perimeter_m, 3),
+                    "perimeter_ft": round(perimeter_ft, 3),
+                },
+            })
+
+        except Exception as e:
+            logger.error("create_room failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Rooms routes registered successfully")

--- a/revit_mcp/rooms.py
+++ b/revit_mcp/rooms.py
@@ -176,6 +176,41 @@ def _unique_number_from(requested, existing):
     return requested  # last resort
 
 
+def _find_placed_rooms_on_level(doc, level, x_ft, y_ft):
+    """Enumerate placed rooms on `level` so callers can see which existing room is
+    likely occupying the area at (x_ft, y_ft). When Revit's IsPointInRoom is
+    available, rooms whose footprint contains the point are flagged first.
+    """
+    out = []
+    test_point = DB.XYZ(x_ft, y_ft, level.Elevation + _mm_to_feet(50.0))
+    rooms = DB.FilteredElementCollector(doc) \
+        .OfCategory(DB.BuiltInCategory.OST_Rooms) \
+        .WhereElementIsNotElementType()
+    for r in rooms:
+        try:
+            if r.LevelId != level.Id:
+                continue
+            if float(r.Area) <= 0.0:
+                continue
+            contains = None
+            try:
+                contains = bool(r.IsPointInRoom(test_point))
+            except Exception:
+                pass
+            name_param = r.get_Parameter(DB.BuiltInParameter.ROOM_NAME)
+            name_str = name_param.AsString() if name_param is not None else ""
+            out.append({
+                "id": element_id_value(r.Id),
+                "number": r.Number,
+                "name": normalize_string(name_str or ""),
+                "contains_requested_point": contains,
+            })
+        except Exception:
+            continue
+    out.sort(key=lambda e: (e.get("contains_requested_point") is not True,))
+    return out
+
+
 def _set_string_param(elem, bip, value):
     """Set a BuiltInParameter string if non-empty and writable. No-op otherwise."""
     if not value:
@@ -238,8 +273,10 @@ def register_rooms_routes(api):
         If both level_id and elevation_mm are omitted, the lowest-elevation
         level in the project is used.
 
-        Returns status='success' with the created room metadata, OR
-        status='not_in_enclosed_area' if the point isn't inside walls/separators.
+        Returns status='success' with the created room metadata; OR
+        status='not_in_enclosed_area' if the point isn't inside walls/separators;
+        OR status='area_already_occupied' if the enclosure already contains a
+        placed room (Revit would otherwise create a junk "unplaced" record).
         """
         try:
             if not doc:
@@ -307,6 +344,22 @@ def register_rooms_routes(api):
                                      x_mm, y_mm, normalize_string(level.Name)),
                         "level_name": normalize_string(level.Name),
                         "level_id": element_id_value(level.Id),
+                    })
+
+                # Revit also returns a non-None room with Area == 0 when the point
+                # falls inside an area already occupied by another placed room. The
+                # new record is "unplaced" — visible in schedules but with no
+                # spatial footprint. Roll back so we don't litter the project.
+                if float(room.Area) == 0.0:
+                    existing = _find_placed_rooms_on_level(doc, level, x_ft, y_ft)
+                    t.RollBack()
+                    return routes.make_response(data={
+                        "status": "area_already_occupied",
+                        "error": "Revit created an unplaced room because the area at ({:.1f}, {:.1f}) on level '{}' is already occupied by another room. Delete or move the existing room before creating a new one in this area.".format(
+                            x_mm, y_mm, normalize_string(level.Name)),
+                        "level_name": normalize_string(level.Name),
+                        "level_id": element_id_value(level.Id),
+                        "existing_rooms_on_level": existing,
                     })
 
                 # Set the name + number first (must be done before any other parameter

--- a/revit_mcp/rooms.py
+++ b/revit_mcp/rooms.py
@@ -16,6 +16,7 @@ batch can be added later if a real workflow demands it.
 
 from pyrevit import routes, revit, DB
 from utils import normalize_string, element_id_value
+from System import Int64
 import json
 import traceback
 import logging
@@ -51,7 +52,7 @@ def _resolve_level(doc, level_id=None, elevation_mm=None):
     """
     if level_id is not None:
         try:
-            lid = DB.ElementId(int(level_id))
+            lid = DB.ElementId(Int64(int(level_id)))
         except Exception:
             return None, "level_id must be an integer"
         el = doc.GetElement(lid)
@@ -206,7 +207,7 @@ def _set_elemid_param(elem, bip, value_id):
     p = elem.get_Parameter(bip)
     if p is not None and not p.IsReadOnly:
         try:
-            p.Set(DB.ElementId(int(value_id)))
+            p.Set(DB.ElementId(Int64(int(value_id))))
         except Exception:
             pass
 

--- a/revit_mcp/selection.py
+++ b/revit_mcp/selection.py
@@ -1,0 +1,59 @@
+# -*- coding: UTF-8 -*-
+"""
+Selection Module for Revit MCP
+Exposes the currently-selected elements in the active Revit UI.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string, element_id_value, get_element_name
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def register_selection_routes(api):
+    """Register all selection-related routes with the API"""
+
+    @api.route("/selection/", methods=["GET"])
+    def get_selected_elements(doc):
+        """Return the elements currently selected by the user in the Revit UI."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            uidoc = revit.uidoc
+            if not uidoc:
+                return routes.make_response(
+                    data={"error": "No active Revit UI document"}, status=503
+                )
+
+            sel_ids = list(uidoc.Selection.GetElementIds())
+            items = []
+            for eid in sel_ids:
+                el = doc.GetElement(eid)
+                if el is None:
+                    continue
+                cat = el.Category
+                type_el = doc.GetElement(el.GetTypeId()) if el.GetTypeId() != DB.ElementId.InvalidElementId else None
+                items.append({
+                    "id": element_id_value(eid),
+                    "name": normalize_string(get_element_name(el)),
+                    "category": normalize_string(cat.Name) if cat else u"(no category)",
+                    "type_id": element_id_value(el.GetTypeId()) if el.GetTypeId() != DB.ElementId.InvalidElementId else None,
+                    "type_name": normalize_string(get_element_name(type_el)) if type_el is not None else None,
+                    "level_id": element_id_value(el.LevelId) if hasattr(el, "LevelId") and el.LevelId != DB.ElementId.InvalidElementId else None,
+                })
+
+            return routes.make_response(data={
+                "status": "success",
+                "count": len(items),
+                "elements": items,
+            })
+
+        except Exception as e:
+            logger.error("get_selected_elements failed: {}".format(str(e)))
+            return routes.make_response(data={"error": str(e)}, status=500)
+
+    logger.info("Selection routes registered successfully")

--- a/revit_mcp/worksets.py
+++ b/revit_mcp/worksets.py
@@ -1,0 +1,127 @@
+# -*- coding: UTF-8 -*-
+"""
+Worksets Module for Revit MCP
+
+Creates user worksets in a workshared model.
+
+Worksets only exist once a document has worksharing enabled. This endpoint
+creates a workset in an ALREADY-workshared model and returns
+status='not_workshared' otherwise -- it deliberately does NOT enable
+worksharing itself, because EnableWorksharing is a one-way, model-wide
+change that should be an explicit user decision, not an implicit side effect.
+
+Worksharing operations are not transactional: Workset.Create must NOT run
+inside a DB.Transaction.
+"""
+
+from pyrevit import routes, revit, DB
+from utils import normalize_string
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_request(request):
+    if not request or not request.data:
+        raise ValueError("No data provided")
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _workset_id_value(workset_id):
+    """Best-effort integer value of a WorksetId, across Revit versions."""
+    try:
+        return workset_id.IntegerValue
+    except Exception:
+        try:
+            return int(str(workset_id))
+        except Exception:
+            return None
+
+
+def _existing_user_worksets(doc):
+    """Return {name: WorksetId} for every user workset in the document."""
+    result = {}
+    collector = DB.FilteredWorksetCollector(doc).OfKind(DB.WorksetKind.UserWorkset)
+    for ws in collector:
+        result[ws.Name] = ws.Id
+    return result
+
+
+def register_workset_routes(api):
+    """Register workset-creation routes."""
+
+    @api.route("/create_workset/", methods=["POST"])
+    def create_workset(doc, request):
+        """
+        Create a user workset in a workshared model.
+
+        Expected payload:
+        {
+            "name": "Shell & Core"   # required, unique within the project
+        }
+
+        Returns status='not_workshared' when the document has no worksharing,
+        status='name_collision' when a workset with that name already exists.
+        """
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503)
+
+            data = _parse_json_request(request)
+            name = data.get("name")
+            if not name or not isinstance(name, str) or not name.strip():
+                return routes.make_response(data={
+                    "error": "Missing required field: name (non-empty string)"
+                }, status=400)
+            name = name.strip()
+
+            if not doc.IsWorkshared:
+                return routes.make_response(data={
+                    "status": "not_workshared",
+                    "error": "This document is not workshared, so it has no user "
+                             "worksets. Enable worksharing in Revit (Collaborate "
+                             "tab) first -- this tool will not enable worksharing "
+                             "implicitly.",
+                })
+
+            # Refuse a duplicate name. Check user worksets first so we can
+            # report the existing id; IsWorksetNameUnique additionally covers
+            # standard/family/view worksets.
+            existing = _existing_user_worksets(doc)
+            if name in existing:
+                return routes.make_response(data={
+                    "status": "name_collision",
+                    "error": "A workset named '{}' already exists.".format(name),
+                    "existing_workset_id": _workset_id_value(existing[name]),
+                })
+            if not DB.WorksetTable.IsWorksetNameUnique(doc, name):
+                return routes.make_response(data={
+                    "status": "name_collision",
+                    "error": "The workset name '{}' is not available.".format(name),
+                })
+
+            # Worksharing operations are not transactional -- no DB.Transaction.
+            new_ws = DB.Workset.Create(doc, name)
+
+            return routes.make_response(data={
+                "status": "success",
+                "workset": {
+                    "id": _workset_id_value(new_ws.Id),
+                    "name": normalize_string(new_ws.Name),
+                    "kind": "UserWorkset",
+                },
+            })
+
+        except Exception as e:
+            logger.error("create_workset failed: {}".format(traceback.format_exc()))
+            return routes.make_response(data={
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }, status=500)
+
+    logger.info("Workset routes registered successfully")

--- a/revit_mcp/worksets.py
+++ b/revit_mcp/worksets.py
@@ -10,8 +10,9 @@ status='not_workshared' otherwise -- it deliberately does NOT enable
 worksharing itself, because EnableWorksharing is a one-way, model-wide
 change that should be an explicit user decision, not an implicit side effect.
 
-Worksharing operations are not transactional: Workset.Create must NOT run
-inside a DB.Transaction.
+Workset.Create modifies the document and so requires an open DB.Transaction.
+(EnableWorksharing itself is non-transactional -- but this tool never calls
+it; enabling worksharing is left to the user.)
 """
 
 from pyrevit import routes, revit, DB
@@ -105,8 +106,11 @@ def register_workset_routes(api):
                     "error": "The workset name '{}' is not available.".format(name),
                 })
 
-            # Worksharing operations are not transactional -- no DB.Transaction.
-            new_ws = DB.Workset.Create(doc, name)
+            # Workset.Create modifies the document -- it requires a transaction.
+            with DB.Transaction(doc, "MCP: Create Workset") as t:
+                t.Start()
+                new_ws = DB.Workset.Create(doc, name)
+                t.Commit()
 
             return routes.make_response(data={
                 "status": "success",

--- a/startup.py
+++ b/startup.py
@@ -79,6 +79,11 @@ def register_routes():
         from revit_mcp.rooms import register_rooms_routes
 
         register_rooms_routes(api)
+
+        # ---- 2026-05-19: dimensions (ported from Sparx) ----
+        from revit_mcp.dimensions import register_dimensions_routes
+
+        register_dimensions_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -115,6 +115,11 @@ def register_routes():
         from revit_mcp.element_operations import register_element_operations_routes
 
         register_element_operations_routes(api)
+
+        # ---- 2026-05-20: workset creation ----
+        from revit_mcp.worksets import register_workset_routes
+
+        register_workset_routes(api)
         # ---- end 2026-05-20 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -111,6 +111,12 @@ def register_routes():
         register_room_data_routes(api)
         # ---- end 2026-05-19 additions ----
 
+        # ---- 2026-05-20: multi-action element operations (ported from Sparx OperateElementCommand) ----
+        from revit_mcp.element_operations import register_element_operations_routes
+
+        register_element_operations_routes(api)
+        # ---- end 2026-05-20 additions ----
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -75,6 +75,12 @@ def register_routes():
         register_levels_routes(api)
         # ---- end 2026-05-18 additions ----
 
+        # ---- 2026-05-19: rooms (ported from Sparx) ----
+        from revit_mcp.rooms import register_rooms_routes
+
+        register_rooms_routes(api)
+        # ---- end 2026-05-19 additions ----
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -104,6 +104,11 @@ def register_routes():
         from revit_mcp.room_annotation import register_room_annotation_routes
 
         register_room_annotation_routes(api)
+
+        # ---- 2026-05-19: room data export (ported from Sparx ExportRoomData) ----
+        from revit_mcp.room_data import register_room_data_routes
+
+        register_room_data_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -120,6 +120,11 @@ def register_routes():
         from revit_mcp.worksets import register_workset_routes
 
         register_workset_routes(api)
+
+        # ---- 2026-05-20: MEP-to-grid dimensioning ----
+        from revit_mcp.mep_dimensions import register_mep_dimensions_routes
+
+        register_mep_dimensions_routes(api)
         # ---- end 2026-05-20 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -45,6 +45,28 @@ def register_routes():
 
         register_document_routes(api)
 
+        # ---- Tools added 2026-05-18: 9 new endpoints ----
+        from revit_mcp.selection import register_selection_routes
+
+        register_selection_routes(api)
+
+        from revit_mcp.element_creation import register_element_creation_routes
+
+        register_element_creation_routes(api)
+
+        from revit_mcp.element_management import register_element_management_routes
+
+        register_element_management_routes(api)
+
+        from revit_mcp.annotation import register_annotation_routes
+
+        register_annotation_routes(api)
+
+        from revit_mcp.integration import register_integration_routes
+
+        register_integration_routes(api)
+        # ---- end 2026-05-18 additions ----
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -89,6 +89,11 @@ def register_routes():
         from revit_mcp.material_quantities import register_material_quantities_routes
 
         register_material_quantities_routes(api)
+
+        # ---- 2026-05-19: structured element filter (ported from Sparx AIElementFilter) ----
+        from revit_mcp.element_filter import register_element_filter_routes
+
+        register_element_filter_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -94,6 +94,11 @@ def register_routes():
         from revit_mcp.element_filter import register_element_filter_routes
 
         register_element_filter_routes(api)
+
+        # ---- 2026-05-19: model-statistics rollup (ported from Sparx AnalyzeModelStatistics) ----
+        from revit_mcp.model_statistics import register_model_statistics_routes
+
+        register_model_statistics_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -69,6 +69,10 @@ def register_routes():
         from revit_mcp.grids import register_grids_routes
 
         register_grids_routes(api)
+
+        from revit_mcp.levels import register_levels_routes
+
+        register_levels_routes(api)
         # ---- end 2026-05-18 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -99,6 +99,11 @@ def register_routes():
         from revit_mcp.model_statistics import register_model_statistics_routes
 
         register_model_statistics_routes(api)
+
+        # ---- 2026-05-19: room tagging (ported from Sparx TagRooms) ----
+        from revit_mcp.room_annotation import register_room_annotation_routes
+
+        register_room_annotation_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -84,6 +84,11 @@ def register_routes():
         from revit_mcp.dimensions import register_dimensions_routes
 
         register_dimensions_routes(api)
+
+        # ---- 2026-05-19: material quantities (ported from Sparx) ----
+        from revit_mcp.material_quantities import register_material_quantities_routes
+
+        register_material_quantities_routes(api)
         # ---- end 2026-05-19 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -65,6 +65,10 @@ def register_routes():
         from revit_mcp.integration import register_integration_routes
 
         register_integration_routes(api)
+
+        from revit_mcp.grids import register_grids_routes
+
+        register_grids_routes(api)
         # ---- end 2026-05-18 additions ----
 
         logger.info("All MCP routes registered successfully")

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -9,6 +9,7 @@ from tools.family_tools import register_family_tools
 from tools.colors_tools import register_colors_tools
 from tools.code_execution_tools import register_code_execution_tools
 from tools.element_operations_tools import register_element_operations_tools
+from tools.workset_tools import register_workset_tools
 
 
 # ---- Status tools ----
@@ -291,3 +292,26 @@ class TestElementOperationsTools:
         )
         payload = self.mock_post.call_args[0][1]
         assert payload["view_id"] == 42
+
+
+# ---- Workset tool ----
+
+class TestWorksetTools:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_mcp, mock_revit_get, mock_revit_post):
+        mock_revit_post.return_value = {
+            "status": "success",
+            "workset": {"id": 1, "name": "Shell & Core"},
+        }
+        register_workset_tools(mock_mcp, mock_revit_get, mock_revit_post)
+        self.tools = mock_mcp.tools
+        self.mock_post = mock_revit_post
+
+    async def test_create_workset_payload(self):
+        await self.tools["create_workset"](name="Shell & Core", ctx=None)
+        endpoint, payload = (
+            self.mock_post.call_args[0][0],
+            self.mock_post.call_args[0][1],
+        )
+        assert endpoint == "/create_workset/"
+        assert payload == {"name": "Shell & Core"}

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -10,6 +10,7 @@ from tools.colors_tools import register_colors_tools
 from tools.code_execution_tools import register_code_execution_tools
 from tools.element_operations_tools import register_element_operations_tools
 from tools.workset_tools import register_workset_tools
+from tools.mep_dimensions_tools import register_mep_dimensions_tools
 
 
 # ---- Status tools ----
@@ -315,3 +316,65 @@ class TestWorksetTools:
         )
         assert endpoint == "/create_workset/"
         assert payload == {"name": "Shell & Core"}
+
+
+# ---- MEP-to-grid dimensioning tool ----
+
+class TestMepDimensionsTools:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_mcp, mock_revit_get, mock_revit_post):
+        mock_revit_post.return_value = {
+            "status": "success",
+            "dimensions_created": 1,
+        }
+        register_mep_dimensions_tools(mock_mcp, mock_revit_get, mock_revit_post)
+        self.tools = mock_mcp.tools
+        self.mock_post = mock_revit_post
+
+    async def test_endpoint_and_defaults(self):
+        await self.tools["dimension_mep_to_grids"](ctx=None)
+        endpoint, payload = (
+            self.mock_post.call_args[0][0],
+            self.mock_post.call_args[0][1],
+        )
+        assert endpoint == "/dimension_mep_to_grids/"
+        assert payload["string_style"] == "continuous"
+        assert payload["grid_scope"] == "nearest"
+        assert payload["offset_mm"] == 2500.0
+        assert payload["gap_mm"] == 1200.0
+        assert payload["coordinate_tolerance_mm"] == 10.0
+        assert payload["max_elements"] == 200
+        assert payload["dry_run"] is False
+        assert payload["view_id"] is None
+        assert payload["element_ids"] is None
+        assert payload["categories"] is None
+        assert payload["dimension_style_id"] is None
+
+    async def test_element_ids_and_view_passed_through(self):
+        await self.tools["dimension_mep_to_grids"](
+            view_id=312, element_ids=[101, 202, 303], ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["view_id"] == 312
+        assert payload["element_ids"] == [101, 202, 303]
+
+    async def test_individual_style_and_overrides(self):
+        await self.tools["dimension_mep_to_grids"](
+            string_style="individual",
+            grid_scope="all",
+            offset_mm=4000.0,
+            gap_mm=2000.0,
+            categories=["ducts", "pipes"],
+            ctx=None,
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["string_style"] == "individual"
+        assert payload["grid_scope"] == "all"
+        assert payload["offset_mm"] == 4000.0
+        assert payload["gap_mm"] == 2000.0
+        assert payload["categories"] == ["ducts", "pipes"]
+
+    async def test_dry_run_passed_through(self):
+        await self.tools["dimension_mep_to_grids"](dry_run=True, ctx=None)
+        payload = self.mock_post.call_args[0][1]
+        assert payload["dry_run"] is True

--- a/tests/unit/test_tool_wrappers.py
+++ b/tests/unit/test_tool_wrappers.py
@@ -8,6 +8,7 @@ from tools.view_tools import register_view_tools
 from tools.family_tools import register_family_tools
 from tools.colors_tools import register_colors_tools
 from tools.code_execution_tools import register_code_execution_tools
+from tools.element_operations_tools import register_element_operations_tools
 
 
 # ---- Status tools ----
@@ -223,3 +224,70 @@ class TestCodeExecutionTools:
             code="print(1)", ctx=None
         )
         assert "Error during code execution" in result
+
+
+# ---- Element-operations tool ----
+
+class TestElementOperationsTools:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_mcp, mock_revit_get, mock_revit_post):
+        mock_revit_post.return_value = {"status": "success", "action": "select"}
+        register_element_operations_tools(
+            mock_mcp, mock_revit_get, mock_revit_post
+        )
+        self.tools = mock_mcp.tools
+        self.mock_post = mock_revit_post
+
+    async def test_select_payload(self):
+        await self.tools["operate_element"](
+            action="select", element_ids=[101, 202], ctx=None
+        )
+        endpoint, payload = self.mock_post.call_args[0][0], self.mock_post.call_args[0][1]
+        assert endpoint == "/operate_element/"
+        assert payload["action"] == "select"
+        assert payload["element_ids"] == [101, 202]
+        assert payload["confirm"] is False
+
+    async def test_set_color_includes_color(self):
+        await self.tools["operate_element"](
+            action="set_color", element_ids=[1], color=[255, 0, 0], ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["color"] == [255, 0, 0]
+        assert "transparency" not in payload
+
+    async def test_set_transparency_includes_transparency(self):
+        await self.tools["operate_element"](
+            action="set_transparency", element_ids=[1], transparency=60, ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["transparency"] == 60
+        assert "color" not in payload
+
+    async def test_delete_confirm_passed_through(self):
+        await self.tools["operate_element"](
+            action="delete", element_ids=[7], confirm=True, ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["action"] == "delete"
+        assert payload["confirm"] is True
+
+    async def test_delete_defaults_to_preview(self):
+        await self.tools["operate_element"](
+            action="delete", element_ids=[7], ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["confirm"] is False
+
+    async def test_reset_isolate_omits_element_ids(self):
+        await self.tools["operate_element"](action="reset_isolate", ctx=None)
+        payload = self.mock_post.call_args[0][1]
+        assert payload["action"] == "reset_isolate"
+        assert "element_ids" not in payload
+
+    async def test_view_id_coerced_to_int(self):
+        await self.tools["operate_element"](
+            action="hide", element_ids=[1], view_id=42, ctx=None
+        )
+        payload = self.mock_post.call_args[0][1]
+        assert payload["view_id"] == 42

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -35,6 +35,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .model_statistics_tools import register_model_statistics_tools
     # Added 2026-05-19 (+1): room tagging (ported from Sparx TagRooms)
     from .room_annotation_tools import register_room_annotation_tools
+    # Added 2026-05-19 (+1): room-data export (ported from Sparx ExportRoomData)
+    from .room_data_tools import register_room_data_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -61,3 +63,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_element_filter_tools(mcp_server, revit_get_func, revit_post_func)
     register_model_statistics_tools(mcp_server, revit_get_func, revit_post_func)
     register_room_annotation_tools(mcp_server, revit_get_func, revit_post_func)
+    register_room_data_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -19,6 +19,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .element_management_tools import register_element_management_tools
     from .annotation_tools import register_annotation_tools
     from .integration_tools import register_integration_tools
+    # Added 2026-05-18 (+1): grids
+    from .grids_tools import register_grids_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -37,3 +39,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_element_management_tools(mcp_server, revit_get_func, revit_post_func)
     register_annotation_tools(mcp_server, revit_get_func, revit_post_func)
     register_integration_tools(mcp_server, revit_get_func, revit_post_func)
+    register_grids_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,6 +13,12 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .code_execution_tools import register_code_execution_tools
     from .launch_tools import register_launch_tools
     from .document_tools import register_document_tools
+    # Added 2026-05-18 (9 new tools): selection / creation / management / annotation / integration
+    from .selection_tools import register_selection_tools
+    from .element_creation_tools import register_element_creation_tools
+    from .element_management_tools import register_element_management_tools
+    from .annotation_tools import register_annotation_tools
+    from .integration_tools import register_integration_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -25,3 +31,9 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     )
     register_launch_tools(mcp_server, revit_get_func)
     register_document_tools(mcp_server, revit_get_func, revit_post_func)
+    # 2026-05-18 additions
+    register_selection_tools(mcp_server, revit_get_func)
+    register_element_creation_tools(mcp_server, revit_get_func, revit_post_func)
+    register_element_management_tools(mcp_server, revit_get_func, revit_post_func)
+    register_annotation_tools(mcp_server, revit_get_func, revit_post_func)
+    register_integration_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -21,6 +21,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .integration_tools import register_integration_tools
     # Added 2026-05-18 (+1): grids
     from .grids_tools import register_grids_tools
+    # Added 2026-05-18 (+1): levels
+    from .levels_tools import register_levels_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -40,3 +42,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_annotation_tools(mcp_server, revit_get_func, revit_post_func)
     register_integration_tools(mcp_server, revit_get_func, revit_post_func)
     register_grids_tools(mcp_server, revit_get_func, revit_post_func)
+    register_levels_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -27,6 +27,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .rooms_tools import register_rooms_tools
     # Added 2026-05-19 (+1): dimensions (ported from Sparx)
     from .dimensions_tools import register_dimensions_tools
+    # Added 2026-05-19 (+1): material quantities (ported from Sparx)
+    from .material_quantities_tools import register_material_quantities_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -49,3 +51,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_levels_tools(mcp_server, revit_get_func, revit_post_func)
     register_rooms_tools(mcp_server, revit_get_func, revit_post_func)
     register_dimensions_tools(mcp_server, revit_get_func, revit_post_func)
+    register_material_quantities_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -39,6 +39,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .room_data_tools import register_room_data_tools
     # Added 2026-05-20 (+1): multi-action element operations (ported from Sparx OperateElementCommand)
     from .element_operations_tools import register_element_operations_tools
+    # Added 2026-05-20 (+1): workset creation
+    from .workset_tools import register_workset_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -67,3 +69,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_room_annotation_tools(mcp_server, revit_get_func, revit_post_func)
     register_room_data_tools(mcp_server, revit_get_func, revit_post_func)
     register_element_operations_tools(mcp_server, revit_get_func, revit_post_func)
+    register_workset_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -23,6 +23,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .grids_tools import register_grids_tools
     # Added 2026-05-18 (+1): levels
     from .levels_tools import register_levels_tools
+    # Added 2026-05-19 (+1): rooms (ported from Sparx)
+    from .rooms_tools import register_rooms_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -43,3 +45,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_integration_tools(mcp_server, revit_get_func, revit_post_func)
     register_grids_tools(mcp_server, revit_get_func, revit_post_func)
     register_levels_tools(mcp_server, revit_get_func, revit_post_func)
+    register_rooms_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -37,6 +37,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .room_annotation_tools import register_room_annotation_tools
     # Added 2026-05-19 (+1): room-data export (ported from Sparx ExportRoomData)
     from .room_data_tools import register_room_data_tools
+    # Added 2026-05-20 (+1): multi-action element operations (ported from Sparx OperateElementCommand)
+    from .element_operations_tools import register_element_operations_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -64,3 +66,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_model_statistics_tools(mcp_server, revit_get_func, revit_post_func)
     register_room_annotation_tools(mcp_server, revit_get_func, revit_post_func)
     register_room_data_tools(mcp_server, revit_get_func, revit_post_func)
+    register_element_operations_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -41,6 +41,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .element_operations_tools import register_element_operations_tools
     # Added 2026-05-20 (+1): workset creation
     from .workset_tools import register_workset_tools
+    # Added 2026-05-20 (+1): MEP-to-grid dimensioning
+    from .mep_dimensions_tools import register_mep_dimensions_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -70,3 +72,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_room_data_tools(mcp_server, revit_get_func, revit_post_func)
     register_element_operations_tools(mcp_server, revit_get_func, revit_post_func)
     register_workset_tools(mcp_server, revit_get_func, revit_post_func)
+    register_mep_dimensions_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -33,6 +33,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .element_filter_tools import register_element_filter_tools
     # Added 2026-05-19 (+1): model-statistics rollup (ported from Sparx AnalyzeModelStatistics)
     from .model_statistics_tools import register_model_statistics_tools
+    # Added 2026-05-19 (+1): room tagging (ported from Sparx TagRooms)
+    from .room_annotation_tools import register_room_annotation_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -58,3 +60,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_material_quantities_tools(mcp_server, revit_get_func, revit_post_func)
     register_element_filter_tools(mcp_server, revit_get_func, revit_post_func)
     register_model_statistics_tools(mcp_server, revit_get_func, revit_post_func)
+    register_room_annotation_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -29,6 +29,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .dimensions_tools import register_dimensions_tools
     # Added 2026-05-19 (+1): material quantities (ported from Sparx)
     from .material_quantities_tools import register_material_quantities_tools
+    # Added 2026-05-19 (+1): structured element filter (ported from Sparx AIElementFilter)
+    from .element_filter_tools import register_element_filter_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -52,3 +54,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_rooms_tools(mcp_server, revit_get_func, revit_post_func)
     register_dimensions_tools(mcp_server, revit_get_func, revit_post_func)
     register_material_quantities_tools(mcp_server, revit_get_func, revit_post_func)
+    register_element_filter_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -25,6 +25,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .levels_tools import register_levels_tools
     # Added 2026-05-19 (+1): rooms (ported from Sparx)
     from .rooms_tools import register_rooms_tools
+    # Added 2026-05-19 (+1): dimensions (ported from Sparx)
+    from .dimensions_tools import register_dimensions_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -46,3 +48,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_grids_tools(mcp_server, revit_get_func, revit_post_func)
     register_levels_tools(mcp_server, revit_get_func, revit_post_func)
     register_rooms_tools(mcp_server, revit_get_func, revit_post_func)
+    register_dimensions_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -31,6 +31,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .material_quantities_tools import register_material_quantities_tools
     # Added 2026-05-19 (+1): structured element filter (ported from Sparx AIElementFilter)
     from .element_filter_tools import register_element_filter_tools
+    # Added 2026-05-19 (+1): model-statistics rollup (ported from Sparx AnalyzeModelStatistics)
+    from .model_statistics_tools import register_model_statistics_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -55,3 +57,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_dimensions_tools(mcp_server, revit_get_func, revit_post_func)
     register_material_quantities_tools(mcp_server, revit_get_func, revit_post_func)
     register_element_filter_tools(mcp_server, revit_get_func, revit_post_func)
+    register_model_statistics_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/annotation_tools.py
+++ b/tools/annotation_tools.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Annotation MCP tools (wall tagging)."""
+
+from typing import Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_annotation_tools(mcp, revit_get, revit_post):
+    """Register annotation tools."""
+
+    @mcp.tool()
+    async def tag_walls(
+        tag_family_name: Optional[str] = None,
+        tag_type_name: Optional[str] = None,
+        leader: bool = False,
+        orientation: str = "horizontal",
+        ctx: Context = None,
+    ) -> str:
+        """
+        Tag every wall visible in the currently active plan view.
+
+        Requires the active view to be a Floor Plan, Ceiling Plan, Engineering
+        Plan, or Area Plan — fails on 3D / Elevation / Section views.
+
+        Args:
+            tag_family_name: Wall-tag family name. Optional; defaults to the
+                             first available wall tag family in the project.
+                             Get the full list of available tag families from
+                             list_families with category_filter="Wall Tags".
+            tag_type_name: Specific tag type within the family. Optional.
+            leader: If True, places each tag with a leader line.
+            orientation: "horizontal" (default) or "vertical".
+
+        Returns tagged_count and (up to 50) wall-id → tag-id pairs.
+        """
+        payload = {
+            "leader": bool(leader),
+            "orientation": orientation,
+        }
+        if tag_family_name:
+            payload["tag_family_name"] = tag_family_name
+        if tag_type_name:
+            payload["tag_type_name"] = tag_type_name
+        response = await revit_post("/tag_walls/", payload, ctx)
+        return format_response(response)

--- a/tools/dimensions_tools.py
+++ b/tools/dimensions_tools.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Dimension-creation MCP tools."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_dimensions_tools(mcp, revit_get, revit_post):
+    """Register dimension-creation tools."""
+
+    @mcp.tool()
+    async def create_dimension(
+        start_x_mm: float,
+        start_y_mm: float,
+        start_z_mm: float,
+        end_x_mm: float,
+        end_y_mm: float,
+        end_z_mm: float,
+        line_x_mm: Optional[float] = None,
+        line_y_mm: Optional[float] = None,
+        line_z_mm: Optional[float] = None,
+        element_ids: Optional[List[int]] = None,
+        view_id: Optional[int] = None,
+        dimension_style_id: Optional[int] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a linear Dimension between two points in a view.
+
+        The dimension's measurement axis is defined by (start -> end). The
+        dimension LINE (where the dim text + witness lines sit) is anchored
+        by `line_*_mm` if supplied, otherwise it is placed 1 ft (304.8 mm)
+        perpendicular to the start->end direction from the midpoint, in the
+        XY plane.
+
+        If `element_ids` is supplied, the dimension is locked to geometric
+        face references on those elements (the typical "dimension between
+        two parallel walls" workflow). For each element, the planar face
+        whose normal is most aligned with the dim direction is picked. Top
+        and bottom horizontal faces (|normal.Z| > 0.9) are skipped — only
+        vertical wall faces are useful in a plan dim.
+
+        If `element_ids` is empty/omitted, the tool falls back to finding
+        the nearest element in the view to each of start/end (within 5 ft)
+        and locking onto the best face there.
+
+        Args:
+            start_x_mm, start_y_mm, start_z_mm: First measured point, in
+                millimetres. Typically lies on or near the first element to
+                dimension (e.g. the centerline of the first wall).
+            end_x_mm, end_y_mm, end_z_mm: Second measured point, in mm.
+                Defines the dim direction together with the start point.
+            line_x_mm, line_y_mm, line_z_mm: Optional dim-line anchor in mm.
+                If supplied, the dim line passes through this point parallel
+                to the start->end direction. If omitted, defaults to a 1 ft
+                perpendicular offset from the midpoint of start/end in XY.
+            element_ids: Optional list of Revit ElementIds (e.g. wall IDs)
+                to dimension between. Provide at least 2 for a clean
+                measurement. Order doesn't matter — references are picked by
+                face-normal alignment with the dim direction.
+            view_id: Optional explicit View ElementId. Defaults to the
+                currently active view in Revit. Must be a 2D view that
+                supports dimensions (FloorPlan, Section, Elevation, etc.).
+            dimension_style_id: Optional DimensionType ElementId to apply
+                to the created dimension. Defaults to the view's current
+                default style.
+
+        Returns the created dimension's id, references_count, measured
+        value (mm and ft), view info, and a diagnostics block showing
+        which path the reference picker took and what it locked onto.
+
+        Status values for recoverable failures:
+            - 'no_references_found'        : zero refs picked
+            - 'fewer_than_2_references'    : only 1 ref picked
+            - 'create_failed'              : Revit refused the dimension
+            - 'invalid_dim_line'           : line construction failed
+            - 'view_not_found'             : view_id invalid or no active view
+
+        Single Ctrl+Z in Revit reverts the creation atomically.
+        """
+        payload = {
+            "start_x_mm": start_x_mm,
+            "start_y_mm": start_y_mm,
+            "start_z_mm": start_z_mm,
+            "end_x_mm": end_x_mm,
+            "end_y_mm": end_y_mm,
+            "end_z_mm": end_z_mm,
+            "line_x_mm": line_x_mm,
+            "line_y_mm": line_y_mm,
+            "line_z_mm": line_z_mm,
+            "element_ids": element_ids,
+            "view_id": view_id,
+            "dimension_style_id": dimension_style_id,
+        }
+        response = await revit_post("/create_dimension/", payload, ctx)
+        return format_response(response)

--- a/tools/element_creation_tools.py
+++ b/tools/element_creation_tools.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Element-creation MCP tools (line-based and surface-based)."""
+
+from typing import List, Dict, Any, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_element_creation_tools(mcp, revit_get, revit_post):
+    """Register line-based + surface-based creation tools."""
+
+    @mcp.tool()
+    async def create_line_based_element(
+        type_name: str,
+        level_name: str,
+        start: Dict[str, float],
+        end: Dict[str, float],
+        height_mm: float,
+        category: str = "wall",
+        structural: bool = False,
+        properties: Optional[Dict[str, Any]] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a line-based element. Currently supports walls only; beams and
+        pipes need MEP/Structural discipline and are not yet wired.
+
+        Args:
+            type_name: Wall type name as it appears in Revit (e.g. "Generic - 200mm").
+                       Look up valid names with list_families if unsure.
+            level_name: Name of the host level (e.g. "Level 1"). Use list_levels.
+            start: Wall start point in MILLIMETRES, project coordinates: {"x":, "y":, "z":}
+            end: Wall end point in mm.
+            height_mm: Wall unconnected height in mm.
+            category: Only "wall" is implemented today. Other values return an error.
+            structural: If True, marks the wall as structural.
+            properties: Optional instance-parameter overrides, e.g. {"Comments": "via MCP"}.
+
+        Returns the new wall's element_id on success.
+        """
+        payload = {
+            "category": category,
+            "type_name": type_name,
+            "level_name": level_name,
+            "start": start,
+            "end": end,
+            "height_mm": height_mm,
+            "structural": structural,
+            "properties": properties or {},
+        }
+        response = await revit_post("/create_line_based_element/", payload, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_surface_based_element(
+        category: str,
+        type_name: str,
+        level_name: str,
+        boundary: List[Dict[str, float]],
+        properties: Optional[Dict[str, Any]] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a surface-based element (floor or ceiling) from a closed boundary.
+
+        Args:
+            category: "floor" or "ceiling".
+            type_name: Type name as it appears in Revit (e.g. "Generic 150mm").
+            level_name: Host level name. Use list_levels.
+            boundary: List of {"x":, "y":, "z":} points in MILLIMETRES, project
+                      coordinates, forming a closed polygon. Minimum 3 points.
+                      The boundary will be auto-closed if the last point doesn't
+                      match the first.
+            properties: Optional instance-parameter overrides.
+
+        Returns the new element's element_id on success. Single-loop boundaries
+        only — slabs with holes (multi-loop) are not yet supported.
+        """
+        payload = {
+            "category": category,
+            "type_name": type_name,
+            "level_name": level_name,
+            "boundary": boundary,
+            "properties": properties or {},
+        }
+        response = await revit_post("/create_surface_based_element/", payload, ctx)
+        return format_response(response)

--- a/tools/element_filter_tools.py
+++ b/tools/element_filter_tools.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Structured element-filter MCP tools (ported from Sparx AIElementFilter)."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_element_filter_tools(mcp, revit_get, revit_post):
+    """Register the structured element-filter tool."""
+
+    @mcp.tool()
+    async def ai_element_filter(
+        filter_category: Optional[str] = None,
+        filter_element_type: Optional[str] = None,
+        filter_family_symbol_id: Optional[int] = None,
+        include_types: bool = False,
+        include_instances: bool = True,
+        filter_visible_in_current_view: bool = False,
+        view_id: Optional[int] = None,
+        bounding_box_min: Optional[List[float]] = None,
+        bounding_box_max: Optional[List[float]] = None,
+        name_contains: Optional[str] = None,
+        max_elements: int = 100,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Find Revit elements matching a structured multi-criteria filter and
+        return rich per-element info.
+
+        Filters are AND'd together. At least one filter is required (the tool
+        will refuse a wide-open scan). The return payload shape depends on
+        each element's kind — see "Returns" below.
+
+        This is the right tool for questions like:
+            - "Find every wall named 'Generic - 200mm'"
+            - "Get all doors visible in the current view"
+            - "List rooms on Level 2 with area / volume / perimeter"
+            - "Find all family instances inside this bounding box"
+
+        Args:
+            filter_category: Optional BuiltInCategory name (with or without
+                the OST_ prefix) to restrict the scan, e.g. "OST_Walls",
+                "Walls", "OST_Doors". Unknown names error out as
+                status='invalid_filter'.
+            filter_element_type: Optional .NET class name under
+                Autodesk.Revit.DB to restrict by class, e.g. "Wall",
+                "FamilyInstance", "Floor". Both bare names and fully
+                qualified names ("Autodesk.Revit.DB.Wall") are accepted.
+            filter_family_symbol_id: Optional FamilySymbol ElementId to
+                restrict to instances of one specific family type. Only
+                meaningful when include_instances=true.
+            include_types: When true, ElementType subclasses (WallType,
+                FloorType, FamilySymbol, ...) are included.
+            include_instances: When true (default), element instances are
+                included. At least one of include_types / include_instances
+                must be true.
+            filter_visible_in_current_view: When true, restrict instances to
+                what's visible in the user's active view. Mutually exclusive
+                with view_id (view_id takes precedence when both are set).
+            view_id: Optional explicit View ElementId. When supplied,
+                instances are restricted to that view's visible set. Useful
+                when you know the target view (e.g. from list_revit_views)
+                without asking the user to focus it.
+            bounding_box_min: Optional [x_mm, y_mm, z_mm] min corner of a
+                3D bounding box. When supplied, only elements whose own
+                bbox intersects this box are returned. Must be provided
+                together with bounding_box_max.
+            bounding_box_max: Optional [x_mm, y_mm, z_mm] max corner of the
+                3D filter. Each axis must be >= the matching min axis.
+            name_contains: Optional case-insensitive substring filter on
+                Element.Name. Applied AFTER the Revit-side collector for
+                element types that don't carry a queryable name.
+            max_elements: Cap on returned element count (default 100). When
+                the matched count exceeds the cap, the response's
+                'truncated' field is true and matched_count > returned_count.
+                Pass 0 for unlimited (use with care on big models).
+
+        Returns a JSON-encoded payload:
+            {
+                "status": "success",
+                "matched_count": 142,          // total before max_elements cap
+                "returned_count": 100,         // actually returned (after cap)
+                "truncated": true,
+                "applied_filters": [           // diagnostics
+                    "instances_only",
+                    "category=OST_Walls",
+                    "name_contains=Generic",
+                    "max_elements=100"
+                ],
+                "view_source": "explicit_view_id" | "no_view_filter",
+                "view_id": 12345 | null,
+                "view_name": "Level 2 Floor Plan" | null,
+                "elements": [
+                    { id, unique_id, name, family_name, category,
+                      built_in_category, element_class, ... kind-specific
+                      fields like bounding_box, level, parameters,
+                      volume_m3, area_m2, position_mm, ... }
+                ]
+            }
+
+        Status values for recoverable failures:
+            - 'invalid_filter' : validation failed (e.g. no filters supplied,
+                                 bad category name, missing one of min/max,
+                                 conflicting include_types+visible_in_view)
+            - 'view_not_found' : view_id was supplied but doesn't resolve
+
+        Per-kind output fields (in addition to the common header
+        id / unique_id / name / family_name / category / built_in_category /
+        element_class):
+
+            HasMaterialQuantities (Wall, Floor, Column, Door, Window, ...)
+                type_id, room_id, level, bounding_box,
+                parameters: [{name:'thickness_mm'}, {name:'bbox_height_mm'}]
+
+            ElementType
+                family_name, parameters: dimensional params + thickness_mm
+
+            Level / Grid
+                bounding_box, level, plus elevation_mm (Level) or
+                grid_line.start_mm/end_mm (Grid)
+
+            Room / Area
+                bounding_box, level, number, area_m2, perimeter_mm
+                (Room also gets volume_m3)
+
+            View
+                bounding_box, view_type, scale, is_template, detail_level,
+                associated_level (ViewPlan only), is_open, is_active
+
+            TextNote / Dimension / IndependentTag / SpotDimension
+                bounding_box, owner_view, position_mm
+                (TextNote -> text_content; Dimension -> dimension_value)
+
+            Group / RevitLinkInstance
+                bounding_box, plus member_count + group_type (Group) or
+                link_path + link_status + position_mm (RevitLinkInstance)
+
+            Fallback (anything else)
+                bounding_box
+
+        No transactions — pure read.
+        """
+        payload = {
+            "filter_category": filter_category,
+            "filter_element_type": filter_element_type,
+            "filter_family_symbol_id": filter_family_symbol_id,
+            "include_types": include_types,
+            "include_instances": include_instances,
+            "filter_visible_in_current_view": filter_visible_in_current_view,
+            "view_id": view_id,
+            "bounding_box_min": bounding_box_min,
+            "bounding_box_max": bounding_box_max,
+            "name_contains": name_contains,
+            "max_elements": max_elements,
+        }
+        response = await revit_post("/ai_element_filter/", payload, ctx)
+        return format_response(response)

--- a/tools/element_management_tools.py
+++ b/tools/element_management_tools.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Element-management MCP tools (delete / modify / reset).
+
+All mutating tools enforce a two-step confirmation: the first call without
+`confirm=True` returns a preview of what would change; the user must then
+re-invoke with `confirm=True` to actually mutate the model. This is enforced
+on both the MCP wrapper (here) AND the pyRevit route (defence in depth).
+"""
+
+from typing import List, Dict, Any, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_element_management_tools(mcp, revit_get, revit_post):
+    """Register delete / modify / reset tools."""
+
+    @mcp.tool()
+    async def delete_elements(
+        element_ids: List[int],
+        confirm: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Delete elements from the Revit model. DESTRUCTIVE.
+
+        Two-step gate: invoke first with confirm=False (default) to see a
+        preview of what would be deleted. Then re-invoke the same call with
+        confirm=True to actually delete.
+
+        Args:
+            element_ids: Integer element IDs to delete.
+            confirm: Must be True to actually execute. False = preview only.
+
+        Walls hosting doors/windows: deleting the wall will also delete the
+        hosted openings (Revit's own behaviour). This is not always desired —
+        prefer modifying over deleting when possible.
+        """
+        payload = {"element_ids": element_ids, "confirm": bool(confirm)}
+        response = await revit_post("/delete_elements/", payload, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def modify_element(
+        element_id: int,
+        parameters: Dict[str, Any],
+        ctx: Context = None,
+    ) -> str:
+        """
+        Modify instance parameters of a single element.
+
+        Args:
+            element_id: Element ID (int) to modify.
+            parameters: Dict of {parameter_name: new_value}. Read-only and
+                        non-existent parameters are skipped (reported in the
+                        response). Numeric parameters use raw values in Revit's
+                        internal units (decimal feet for length).
+
+        No preview/confirm gate — parameter changes are routinely reversible
+        via Revit's undo stack. For bulk changes across many elements, prefer
+        calling this multiple times rather than execute_revit_code.
+        """
+        payload = {"element_id": int(element_id), "parameters": parameters}
+        response = await revit_post("/modify_element/", payload, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def reset_model(
+        categories: Optional[List[str]] = None,
+        confirm: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Delete all instances of the specified categories from the model. HIGHLY DESTRUCTIVE.
+
+        Does NOT delete views, levels, sheets, family types, or other "project
+        skeleton" content — only the geometric instances in the named categories.
+
+        Two-step gate: must call with confirm=True to actually wipe.
+
+        Args:
+            categories: List of category names (e.g. ["walls", "doors", "windows"]).
+                        Supported aliases: walls, floors, ceilings, roofs, doors,
+                        windows, furniture, generic_model, stairs, railings,
+                        columns, structural_framing, structural_columns,
+                        structural_foundation. If omitted, uses a built-in safe
+                        default list covering the architectural categories.
+            confirm: Must be True to actually execute. False = preview only.
+
+        Recovery: only via Revit's undo stack (Ctrl+Z) immediately after. If
+        the file is saved before noticing, recovery requires opening a backup.
+        """
+        payload = {"confirm": bool(confirm)}
+        if categories:
+            payload["categories"] = categories
+        response = await revit_post("/reset_model/", payload, ctx)
+        return format_response(response)

--- a/tools/element_operations_tools.py
+++ b/tools/element_operations_tools.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Element-operations MCP tool.
+
+A single multi-action dispatcher for view-state, selection, and visibility
+operations on a set of elements. Ported from the Sparx mcp-servers-for-revit
+`OperateElementCommand`.
+"""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_element_operations_tools(mcp, revit_get, revit_post):
+    """Register the operate_element tool."""
+
+    @mcp.tool()
+    async def operate_element(
+        action: str,
+        element_ids: Optional[List[int]] = None,
+        color: Optional[List[int]] = None,
+        transparency: Optional[int] = None,
+        view_id: Optional[int] = None,
+        confirm: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Perform a view-state, selection, or visibility operation on a set of
+        elements. One tool, many actions.
+
+        Args:
+            action: One of --
+                select           -- set the Revit UI selection to these elements
+                selection_box    -- enable a 3D section box around these elements
+                set_color        -- override colour in a view (needs `color`)
+                set_transparency -- override surface transparency (needs `transparency`)
+                hide             -- permanently hide elements in a view
+                unhide           -- un-hide elements in a view
+                temp_hide        -- temporarily hide (session-only view mode)
+                isolate          -- temporarily isolate (session-only view mode)
+                reset_isolate    -- clear the temporary hide/isolate view mode
+                delete           -- delete elements (confirm-gated)
+            element_ids: Integer element IDs to operate on. Required for every
+                action except reset_isolate.
+            color: [r, g, b] with values 0-255 -- required for set_color.
+            transparency: 0 (opaque) to 100 (fully transparent) -- required for
+                set_transparency.
+            view_id: Optional view to target. Defaults to the active view; for
+                selection_box it must be a 3D view (a 3D view is auto-found and
+                activated if omitted).
+            confirm: For action="delete" only -- must be True to actually
+                delete. False (default) returns a preview. Ignored otherwise.
+
+        The `delete` action is confirm-gated for safety; for delete-only
+        workflows prefer the dedicated delete_elements tool. Temporary view
+        modes set by temp_hide / isolate are cleared with action=reset_isolate.
+        """
+        payload = {"action": action, "confirm": bool(confirm)}
+        if element_ids is not None:
+            payload["element_ids"] = element_ids
+        if color is not None:
+            payload["color"] = color
+        if transparency is not None:
+            payload["transparency"] = transparency
+        if view_id is not None:
+            payload["view_id"] = int(view_id)
+        response = await revit_post("/operate_element/", payload, ctx)
+        return format_response(response)

--- a/tools/grids_tools.py
+++ b/tools/grids_tools.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Grid-generation MCP tools."""
+
+from typing import Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_grids_tools(mcp, revit_get, revit_post):
+    """Register grid-generation tools."""
+
+    @mcp.tool()
+    async def create_grids_from_walls(
+        tolerance_mm: float = 10.0,
+        padding_mm: float = 3000.0,
+        start_vertical_number: int = 1,
+        start_horizontal_letter: str = "A",
+        vertical_prefix: str = "",
+        horizontal_prefix: str = "",
+        dry_run: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Generate a project grid system from existing wall centerlines.
+
+        Walks every wall in the active document; for each axis-aligned wall
+        (vertical or horizontal in plan), takes its centerline X (vertical
+        walls) or Y (horizontal walls) and emits a grid line there. Walls
+        within `tolerance_mm` of an existing centerline collapse into the
+        same grid (averaged position).
+
+        - Vertical grids run along the Y axis (constant X), numbered "1",
+          "2", "3", ... from the LEFT (smallest X)
+        - Horizontal grids run along the X axis (constant Y), lettered "A",
+          "B", "C", ..., "AA", "AB", ... from the SOUTH (smallest Y)
+
+        All grids are created in a SINGLE transaction so the entire grid
+        system reverts on a single Ctrl+Z in Revit.
+
+        Args:
+            tolerance_mm: Walls whose centerlines are within this distance
+                          on the same axis collapse into one grid. Default 10mm.
+            padding_mm: Each grid line extends this distance beyond the
+                        building bounding box on both ends (so bubbles sit
+                        outside the building). Default 3000mm.
+            start_vertical_number: First number for vertical grids.
+                                   Default 1 → grids "1", "2", "3", ...
+            start_horizontal_letter: First letter for horizontal grids.
+                                     Default "A" → grids "A", "B", "C", ...
+                                     Use "G" to start at "G".
+            vertical_prefix: Optional prefix on each vertical grid name.
+                             E.g. "V-" → grids "V-1", "V-2", ...
+            horizontal_prefix: Optional prefix on each horizontal grid name.
+                               E.g. "H-" → grids "H-A", "H-B", ...
+            dry_run: If True, report what would be created without modifying
+                     the model. Safe preview before committing.
+
+        Returns counts + per-grid (name, coordinate, element ID) lists.
+        Fails cleanly with a descriptive status if there are no walls,
+        no axis-aligned walls, or grid-name collisions with existing grids.
+
+        Curved walls and diagonal walls are reported in the response but
+        do not contribute grid lines (axis-aligned only).
+        """
+        payload = {
+            "tolerance_mm": tolerance_mm,
+            "padding_mm": padding_mm,
+            "start_vertical_number": start_vertical_number,
+            "start_horizontal_letter": start_horizontal_letter,
+            "vertical_prefix": vertical_prefix,
+            "horizontal_prefix": horizontal_prefix,
+            "dry_run": dry_run,
+        }
+        response = await revit_post("/create_grids_from_walls/", payload, ctx)
+        return format_response(response)

--- a/tools/integration_tools.py
+++ b/tools/integration_tools.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Integration MCP tools (extension discovery + invocation)."""
+
+from typing import Optional, List, Dict, Any
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_integration_tools(mcp, revit_get, revit_post):
+    """Register module-discovery and module-invocation tools."""
+
+    @mcp.tool()
+    async def search_modules(
+        query: Optional[str] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        List installed pyRevit extensions on this machine, optionally filtered
+        by name substring.
+
+        Args:
+            query: Case-insensitive substring filter on extension folder name.
+                   Omit to list all extensions.
+
+        Returns one entry per extension with: name, path, type ('ui' or 'lib'),
+        has_lib (whether it has a lib/ directory you can import from), and
+        command_count (number of .pushbutton folders, UI extensions only).
+        """
+        payload = {"query": query} if query else {}
+        # GET when no body, POST when filtering
+        if query:
+            response = await revit_post("/search_modules/", payload, ctx)
+        else:
+            response = await revit_get("/search_modules/", ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def use_module(
+        extension_name: str,
+        module_path: str,
+        function_name: str,
+        args: Optional[List[Any]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+        confirm: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Import a named module from a named pyRevit extension's lib/ directory
+        and call a named function. Stricter than execute_revit_code — the
+        callable must already exist in the extension; no arbitrary statements.
+
+        Two-step gate: must call with confirm=True to actually invoke. First
+        call returns a preview describing what would be invoked.
+
+        Args:
+            extension_name: Full folder name (e.g. "MyTools.extension" or
+                            "MyLib.lib"). Use search_modules to find it.
+            module_path: Dotted import path under <extension>/lib/
+                         (e.g. "submodule.helpers").
+            function_name: Name of the callable to invoke.
+            args: Positional args list (JSON-serialisable).
+            kwargs: Keyword args dict (JSON-serialisable).
+            confirm: Must be True to actually invoke. False = preview only.
+
+        Return value: whatever the called function returns, best-effort
+        JSON-serialised (non-JSON types stringified).
+
+        Caveat: invoked code runs inside Revit's IronPython process with full
+        Revit API access. Treat the extension list as you would `sudo` — only
+        invoke functions from extensions you trust.
+        """
+        payload = {
+            "extension_name": extension_name,
+            "module_path": module_path,
+            "function_name": function_name,
+            "args": args or [],
+            "kwargs": kwargs or {},
+            "confirm": bool(confirm),
+        }
+        response = await revit_post("/use_module/", payload, ctx)
+        return format_response(response)

--- a/tools/levels_tools.py
+++ b/tools/levels_tools.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Level-creation MCP tools."""
+
+from typing import Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_levels_tools(mcp, revit_get, revit_post):
+    """Register level-creation tools."""
+
+    @mcp.tool()
+    async def create_level(
+        name: str,
+        elevation_mm: float,
+        create_floor_plan: bool = True,
+        create_ceiling_plan: bool = False,
+        view_name: Optional[str] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a level at a given elevation and (optionally) matching plan views.
+
+        All elements (level + views) are created in a single transaction so
+        one Ctrl+Z in Revit reverts the entire creation.
+
+        Args:
+            name: Level name as it should appear in Revit (e.g. "Level 3").
+                  Must be unique in the project — call fails with
+                  status=name_collision if a level with the same name exists.
+            elevation_mm: Elevation in MILLIMETRES (positive = up from project
+                          base). Internally converted to Revit's decimal feet.
+            create_floor_plan: If True (default), also creates a Floor Plan
+                               view linked to the new level.
+            create_ceiling_plan: If True, also creates a Ceiling Plan view.
+                                 Default False. When both plans are created,
+                                 the ceiling plan name gets " - Ceiling"
+                                 suffix to avoid duplicate-name collision.
+            view_name: Custom name for the created view(s). Defaults to the
+                       level name. Useful if you want the view to be named
+                       differently from the level (e.g. level "L+3" with
+                       view "Third Floor").
+
+        Returns the new level + view element IDs on success.
+        """
+        payload = {
+            "name": name,
+            "elevation_mm": float(elevation_mm),
+            "create_floor_plan": bool(create_floor_plan),
+            "create_ceiling_plan": bool(create_ceiling_plan),
+        }
+        if view_name:
+            payload["view_name"] = view_name
+        response = await revit_post("/create_level/", payload, ctx)
+        return format_response(response)

--- a/tools/material_quantities_tools.py
+++ b/tools/material_quantities_tools.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Material-quantity extraction MCP tools."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_material_quantities_tools(mcp, revit_get, revit_post):
+    """Register material-quantity extraction tools."""
+
+    @mcp.tool()
+    async def get_material_quantities(
+        category_filter: Optional[List[str]] = None,
+        element_ids: Optional[List[int]] = None,
+        view_id: Optional[int] = None,
+        include_zero_volume: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Roll up material volumes (m3) and areas (m2) across the Revit model.
+
+        Walks every element in the chosen scope, calls GetMaterialIds /
+        GetMaterialVolume / GetMaterialArea on each, and groups the results
+        by material. Returns a per-material breakdown (name, class, volume,
+        area, element count, categories the material appeared on) and a
+        totals block.
+
+        This is the right tool for questions like:
+            - "How much concrete is in the building?"
+            - "What's the total area of Brick - Common in walls and floors?"
+            - "Which material has the largest volume?"
+
+        Args:
+            category_filter: Optional list of BuiltInCategory names to
+                restrict the scan to (e.g. ["OST_Walls", "OST_Floors",
+                "OST_StructuralColumns"]). Names with or without the OST_
+                prefix are both accepted. Unknown names are skipped and
+                returned in `invalid_category_names`. None = all categories.
+            element_ids: Optional list of Revit ElementIds to restrict the
+                scan to. When provided, supersedes view_id. None = all
+                elements in scope.
+            view_id: Optional View ElementId. When provided (and element_ids
+                isn't), the scan is limited to elements visible in this
+                view. Useful for "what's in the third-floor plan view?".
+            include_zero_volume: If False (default), drops materials that
+                contribute zero m3 AND zero m2. These usually come from
+                thin-paint applications that GetMaterialIds(False) shouldn't
+                include but occasionally leak through.
+
+        Returns a JSON-encoded breakdown sorted by volume descending:
+            {
+                "status": "success",
+                "materials": [
+                    {
+                        "material_id": 123,
+                        "material_name": "Concrete - Cast-in-Place",
+                        "material_class": "Concrete",
+                        "volume_m3": 14.732,
+                        "area_m2": 65.4,
+                        "element_count": 18,
+                        "categories": ["Floors", "Walls"]
+                    },
+                    ...
+                ],
+                "totals": { "material_count": N, "volume_m3": X,
+                            "area_m2": Y, "element_count": Z },
+                "picker_path": ...,
+                "elements_scanned": ...
+            }
+
+        Status values for recoverable failures:
+            - 'no_elements_found' : filter produced an empty element set
+            - 'view_not_found'    : view_id was supplied but invalid
+
+        No transactions — pure read.
+        """
+        payload = {
+            "category_filter": category_filter,
+            "element_ids": element_ids,
+            "view_id": view_id,
+            "include_zero_volume": include_zero_volume,
+        }
+        response = await revit_post("/get_material_quantities/", payload, ctx)
+        return format_response(response)

--- a/tools/mep_dimensions_tools.py
+++ b/tools/mep_dimensions_tools.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""MEP-to-grid dimensioning MCP tool."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_mep_dimensions_tools(mcp, revit_get, revit_post):
+    """Register the dimension_mep_to_grids tool."""
+
+    @mcp.tool()
+    async def dimension_mep_to_grids(
+        view_id: Optional[int] = None,
+        element_ids: Optional[List[int]] = None,
+        categories: Optional[List[str]] = None,
+        string_style: str = "continuous",
+        grid_scope: str = "nearest",
+        offset_mm: float = 2500.0,
+        gap_mm: float = 1200.0,
+        coordinate_tolerance_mm: float = 10.0,
+        max_elements: int = 200,
+        dimension_style_id: Optional[int] = None,
+        dry_run: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Automatically dimension MEP elements (ducts, cable trays, pipes) to
+        the project grid system in a plan view, laid out with clean spacing.
+
+        This is the "locate the services against the grid" workflow from an
+        MEP coordination drawing. Each MEP run is dimensioned to the grid
+        lines that box it in:
+
+        - A horizontal (East-West) run is located by its Y coordinate, so it
+          is dimensioned against the HORIZONTAL grids with a VERTICAL
+          dimension string.
+        - A vertical (North-South) run is located by its X coordinate, so it
+          is dimensioned against the VERTICAL grids with a HORIZONTAL string.
+        - Vertical risers (a point in plan) and diagonal runs are skipped and
+          reported.
+
+        Witness references lock onto grid lines and MEP centerlines. A
+        continuous string is one multi-segment dimension witnessing the
+        chosen grids plus every MEP centerline in coordinate order.
+
+        Args:
+            view_id: Optional plan-view ElementId. Defaults to the active
+                view. Must be a plan view (FloorPlan / CeilingPlan /
+                EngineeringPlan / AreaPlan).
+            element_ids: Optional explicit list of MEP element ids to
+                dimension. STRONGLY RECOMMENDED for real models -- a busy
+                MEP view can hold hundreds of ducts and dimensioning them all
+                is unreadable. When omitted, every MEP element of the
+                requested categories visible in the view is used, subject to
+                max_elements.
+            categories: Which MEP categories to include when falling back to
+                view-visible elements. Any of "ducts", "cable_trays",
+                "pipes" (aliases like "duct", "OST_PipeCurves" also accepted).
+                Defaults to all three. Ignored when element_ids is given.
+            string_style: "continuous" (default) = ONE continuous
+                multi-segment dimension string per orientation, witnessing
+                the chosen grids and every MEP centerline. "individual" =
+                one separate grid->run->grid dimension per MEP run, greedily
+                lane-stacked to avoid overlaps.
+            grid_scope: "nearest" (default) = only the grids immediately
+                bracketing the MEP runs are witnessed. "all" = every grid of
+                the relevant orientation visible in the view is witnessed.
+            offset_mm: Distance the dimension line is placed clear of the
+                dimensioned MEP geometry, in mm. Default 2500.
+            gap_mm: Gap between stacked dimension strings (individual mode
+                only), in mm. Default 1200.
+            coordinate_tolerance_mm: MEP runs whose locating coordinate is
+                within this distance collapse to a single witnessed
+                coordinate; a run sitting on a grid line within this
+                tolerance is dropped. Default 10.
+            max_elements: Safety cap on the view-visible fallback. If more
+                MEP elements than this are visible, the tool returns
+                'too_many_elements' instead of producing an unreadable
+                drawing. Default 200. Ignored when element_ids is supplied.
+            dimension_style_id: Optional DimensionType ElementId to apply.
+            dry_run: If true, report the planned strings and witnesses
+                without modifying the model.
+
+        Returns the created dimension ids with per-string segment values
+        (mm), the grids/MEP counts, and diagnostics: skipped_mep (with
+        reasons such as 'vertical_riser', 'diagonal_run',
+        'coincides_with_grid'), warnings, and create_errors.
+
+        Recoverable status values:
+            - 'view_not_plan'        : target view is not a plan view
+            - 'view_not_found'       : view_id invalid / no active view
+            - 'no_grids'             : no axis-aligned grids in the view
+            - 'no_mep_elements'      : no dimensionable MEP found
+            - 'no_dimensionable_mep' : MEP found but all risers/diagonal
+            - 'too_many_elements'    : view-visible count exceeds max_elements
+            - 'nothing_created'      : nothing could be planned
+            - 'create_failed'        : Revit refused every string
+
+        All strings are created in one transaction -- a single Ctrl+Z in
+        Revit reverts the whole set.
+        """
+        payload = {
+            "view_id": view_id,
+            "element_ids": element_ids,
+            "categories": categories,
+            "string_style": string_style,
+            "grid_scope": grid_scope,
+            "offset_mm": offset_mm,
+            "gap_mm": gap_mm,
+            "coordinate_tolerance_mm": coordinate_tolerance_mm,
+            "max_elements": max_elements,
+            "dimension_style_id": dimension_style_id,
+            "dry_run": dry_run,
+        }
+        response = await revit_post("/dimension_mep_to_grids/", payload, ctx)
+        return format_response(response)

--- a/tools/model_statistics_tools.py
+++ b/tools/model_statistics_tools.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Model-statistics rollup MCP tools."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_model_statistics_tools(mcp, revit_get, revit_post):
+    """Register the model-statistics rollup tool."""
+
+    @mcp.tool()
+    async def analyze_model_statistics(
+        category_filter: Optional[List[str]] = None,
+        view_id: Optional[int] = None,
+        include_detailed_types: bool = True,
+        top_n_categories: Optional[int] = None,
+        top_n_types_per_category: Optional[int] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Roll up project-level statistics: counts, categories, types, levels.
+
+        Walks every element in the chosen scope and produces a structured
+        breakdown of:
+            - project-wide totals (elements / types / families / views / sheets)
+            - per-category counts with optional drill-down into types
+              (type_name + family_name + instance_count)
+            - per-level element counts with elevations in mm
+
+        This is the right tool for questions like:
+            - "How many walls / doors / windows are in this project?"
+            - "What categories carry the most elements?"
+            - "Which generic-model families have the most instances?"
+            - "What's on Level 2 vs Level 1?"
+
+        Args:
+            category_filter: Optional list of BuiltInCategory names
+                (e.g. ["OST_Walls", "OST_Doors"]; with or without OST_
+                prefix). Restricts the per-category drill-down. The headline
+                totals (elements/types/families/views/sheets) and per-level
+                rollup are always project-wide. None = all categories.
+            view_id: Optional View ElementId. When provided, the
+                per-category drill-down is limited to elements visible in
+                this view. The headline totals and per-level rollup remain
+                project-wide.
+            include_detailed_types: When True (default), each category in
+                the result carries a `types` list with type_name /
+                family_name / instance_count. When False, only the counts
+                are returned (much smaller payload for large models).
+            top_n_categories: Optional cap on the categories returned.
+                Categories are sorted by element_count desc, then name.
+                When applied, `truncated_categories=true` in the response.
+            top_n_types_per_category: Optional cap on the types inside each
+                category. Types within a category are sorted by
+                instance_count desc, then type_name. When applied to any
+                category, `truncated_types_per_category=true` and the
+                per-category `types_truncated=true` flag is set.
+
+        Returns a JSON-encoded breakdown:
+            {
+                "status": "success",
+                "project_name": "Project1",
+                "totals": {
+                    "elements": N, "types": N, "families": N,
+                    "views": N, "sheets": N
+                },
+                "categories": [
+                    {
+                        "category_name": "Walls",
+                        "element_count": N,
+                        "type_count": N,
+                        "family_count": N,
+                        "types": [
+                            {"type_name": "Generic - 200mm",
+                             "family_name": "Basic Wall",
+                             "instance_count": N}
+                        ],
+                        "types_truncated": false
+                    }
+                ],
+                "levels": [
+                    {"level_id": 311,
+                     "level_name": "Level 1",
+                     "elevation_mm": 0.0,
+                     "element_count": N}
+                ],
+                "applied_filters": [...],
+                "view_source": "...",
+                "view_id": ...,
+                "view_name": ...,
+                "invalid_category_names": [...],
+                "truncated_categories": false,
+                "truncated_types_per_category": false
+            }
+
+        Status values for recoverable failures:
+            - 'view_not_found' : view_id was supplied but invalid
+
+        No transactions — pure read.
+        """
+        payload = {
+            "category_filter": category_filter,
+            "view_id": view_id,
+            "include_detailed_types": include_detailed_types,
+            "top_n_categories": top_n_categories,
+            "top_n_types_per_category": top_n_types_per_category,
+        }
+        response = await revit_post("/analyze_model_statistics/", payload, ctx)
+        return format_response(response)

--- a/tools/room_annotation_tools.py
+++ b/tools/room_annotation_tools.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Room-tagging MCP tools."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_room_annotation_tools(mcp, revit_get, revit_post):
+    """Register the bulk room-tagging tool."""
+
+    @mcp.tool()
+    async def tag_rooms(
+        room_ids: Optional[List[int]] = None,
+        tag_family_name: Optional[str] = None,
+        tag_type_name: Optional[str] = None,
+        tag_type_id: Optional[int] = None,
+        leader: bool = False,
+        view_id: Optional[int] = None,
+        auto_switch_view: bool = True,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Bulk-place RoomTag elements over rooms in a plan view.
+
+        This is the room equivalent of `tag_walls`. By default it tags every
+        room visible in the active plan view; with `room_ids` it tags only
+        the specified rooms (auto-switching the active view to a matching
+        FloorPlan on the rooms' level if needed and `auto_switch_view=True`).
+
+        Skip rules:
+            - Rooms with Area <= 0 (unplaced)        -> counted in skipped_unplaced
+            - Rooms that already have a tag in view  -> counted in skipped_existing
+
+        Args:
+            room_ids: Optional list of Room ElementIds to tag. When omitted,
+                every placed room visible in the target view is tagged.
+            tag_family_name: Room-tag family name (e.g. "Room Tag"). Optional;
+                defaults to the first RoomTag family found in the project.
+            tag_type_name: Specific tag type within the family. Optional.
+            tag_type_id: Explicit RoomTag FamilySymbol ElementId. Overrides
+                name-based lookup. Useful when the tag type's name collides
+                with another family's type.
+            leader: When True, places each tag with a leader line.
+            view_id: Optional View ElementId to target. When omitted, uses
+                `uidoc.ActiveView`. Either way, the view must be a plan view
+                bound to the rooms' level — see `auto_switch_view`.
+            auto_switch_view: When True (default), if the target view isn't
+                a plan view or isn't on the rooms' level, automatically
+                switches the active view to a matching FloorPlan view. When
+                False, the call fails with `view_not_supported` instead.
+
+        Returns a JSON-encoded breakdown:
+            {
+                "status": "success",
+                "view_id": ..., "view_name": ..., "view_switched": false,
+                "previous_view_name": null,
+                "tag_family": "Room Tag", "tag_type": "Standard",
+                "tag_type_id": ...,
+                "total_rooms": N,
+                "tagged_count": N,
+                "skipped_existing": N,
+                "skipped_unplaced": N,
+                "tags": [
+                    {"tag_id": ..., "room_id": ..., "room_name": "Office",
+                     "room_number": "101",
+                     "location_mm": {"x": ..., "y": ..., "z": ...}}
+                ],
+                "tags_truncated": false,   // true when more than 100 tags placed
+                "errors": [...],
+                "invalid_room_ids": [...]
+            }
+
+        Status values for recoverable failures:
+            - 'view_not_supported'  : view isn't a plan view on the rooms'
+                                      level and auto_switch_view is False
+            - 'no_room_tag_family'  : no RoomTag FamilySymbol in the project
+            - 'view_not_found'      : explicit view_id was invalid
+            - 'no_rooms_in_view'    : view-scoped scan returned 0 rooms
+
+        Single Ctrl+Z in Revit reverts the entire batch atomically.
+
+        Duplicate-room-number warnings raised by Revit during tag placement
+        are silently suppressed (matches Sparx behavior — these are usually
+        noise from rooms across linked models).
+        """
+        payload = {
+            "leader": bool(leader),
+            "auto_switch_view": bool(auto_switch_view),
+        }
+        if room_ids is not None:
+            payload["room_ids"] = list(room_ids)
+        if tag_family_name:
+            payload["tag_family_name"] = tag_family_name
+        if tag_type_name:
+            payload["tag_type_name"] = tag_type_name
+        if tag_type_id is not None:
+            payload["tag_type_id"] = tag_type_id
+        if view_id is not None:
+            payload["view_id"] = view_id
+        response = await revit_post("/tag_rooms/", payload, ctx)
+        return format_response(response)

--- a/tools/room_data_tools.py
+++ b/tools/room_data_tools.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Room-data extraction MCP tools."""
+
+from typing import List, Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_room_data_tools(mcp, revit_get, revit_post):
+    """Register the room-data export tool."""
+
+    @mcp.tool()
+    async def export_room_data(
+        room_ids: Optional[List[int]] = None,
+        level_id: Optional[int] = None,
+        level_name: Optional[str] = None,
+        view_id: Optional[int] = None,
+        phase_id: Optional[int] = None,
+        include_unplaced: bool = False,
+        include_not_enclosed: bool = False,
+        sort_by: str = "number",
+        ctx: Context = None,
+    ) -> str:
+        """
+        Export every Room in the project (or a filtered subset) as JSON.
+
+        Returns the full parameter set for each room: name, number, level,
+        phase, area (m²), volume (m³), perimeter (mm), unbounded height
+        (mm), department, occupancy, comments, location_mm, bounding_box_mm.
+        Each room is classified by `placement`: 'placed' / 'unplaced' /
+        'not_enclosed'.
+
+        This is the right tool for questions like:
+            - "Give me a list of every room with area and number."
+            - "Export rooms on Level 2 as a schedule."
+            - "Which rooms are unplaced or not enclosed?"
+            - "Total area of all bedrooms on the second floor."
+
+        Args:
+            room_ids: Optional explicit list of Room ElementIds. When
+                provided, supersedes level/view/phase filters.
+            level_id: Optional Level ElementId to restrict the export to.
+            level_name: Optional Level name (alternate to level_id).
+                Either works; level_id takes precedence if both supplied.
+            view_id: Optional View ElementId — when provided, restricts
+                rooms to those visible in this view AND uses this view for
+                bounding-box clipping.
+            phase_id: Optional Phase ElementId — restrict to rooms in this
+                phase. Useful for renovation projects where rooms split
+                across Existing / New Construction.
+            include_unplaced: When True, rooms with no Location (Revit's
+                "Not Placed" schedule bucket) are included. Default False
+                (omitted from results, counted in `skipped_unplaced`).
+            include_not_enclosed: When True, rooms with a Location but
+                Area==0 (boundary doesn't form a closed loop) are
+                included. Default False.
+            sort_by: One of "number" (default; natural-numeric: 101, 101A,
+                102), "name", "level", or "area" (descending).
+
+        Returns a JSON-encoded breakdown:
+            {
+                "status": "success",
+                "rooms": [
+                    {
+                        "id": 354978,
+                        "unique_id": "...-00056abd",
+                        "name": "Office",
+                        "number": "101",
+                        "placement": "placed",
+                        "level_id": 311, "level_name": "Level 1",
+                        "phase_id": ..., "phase_name": "New Construction",
+                        "area_m2": 18.42, "volume_m3": 55.27,
+                        "perimeter_mm": 17400.0,
+                        "unbounded_height_mm": 3000.0,
+                        "department": "Admin", "occupancy": "Office",
+                        "comments": "...",
+                        "location_mm": {"x": ..., "y": ..., "z": ...},
+                        "bounding_box_mm": {"min": {...}, "max": {...}}
+                    }
+                ],
+                "totals": {
+                    "room_count": N, "area_m2": ..., "volume_m3": ...,
+                    "placed_count": N, "unplaced_count": N,
+                    "not_enclosed_count": N
+                },
+                "applied_filters": [...],
+                "skipped_unplaced": N, "skipped_not_enclosed": N,
+                "skipped_other_level": N, "skipped_other_phase": N,
+                "invalid_room_ids": [...],
+                "level_filter": "Level 1", "phase_filter": null,
+                "view_filter": null, "sort_by": "number"
+            }
+
+        Status values for recoverable failures:
+            - 'no_rooms_found'   : filter produced an empty set
+            - 'level_not_found'  : explicit level_id or level_name invalid
+            - 'phase_not_found'  : explicit phase_id invalid
+            - 'view_not_found'   : explicit view_id invalid
+
+        No transactions — pure read.
+        """
+        payload = {
+            "include_unplaced": bool(include_unplaced),
+            "include_not_enclosed": bool(include_not_enclosed),
+            "sort_by": sort_by,
+        }
+        if room_ids is not None:
+            payload["room_ids"] = list(room_ids)
+        if level_id is not None:
+            payload["level_id"] = level_id
+        if level_name:
+            payload["level_name"] = level_name
+        if view_id is not None:
+            payload["view_id"] = view_id
+        if phase_id is not None:
+            payload["phase_id"] = phase_id
+        response = await revit_post("/export_room_data/", payload, ctx)
+        return format_response(response)

--- a/tools/rooms_tools.py
+++ b/tools/rooms_tools.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Room-creation MCP tools."""
+
+from typing import Optional
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_rooms_tools(mcp, revit_get, revit_post):
+    """Register room-creation tools."""
+
+    @mcp.tool()
+    async def create_room(
+        x_mm: float,
+        y_mm: float,
+        level_id: Optional[int] = None,
+        elevation_mm: Optional[float] = None,
+        name: str = "Room",
+        number: Optional[str] = None,
+        upper_limit_id: Optional[int] = None,
+        limit_offset_mm: Optional[float] = None,
+        base_offset_mm: Optional[float] = 0,
+        department: Optional[str] = None,
+        comments: Optional[str] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a Room element at a 2D point on a level.
+
+        The point must lie inside an area enclosed by room-bounding elements
+        (walls or room separators); otherwise Revit refuses to create the room
+        and the tool returns status='not_in_enclosed_area'.
+
+        Args:
+            x_mm: Room location X in millimetres.
+            y_mm: Room location Y in millimetres.
+            level_id: Optional explicit Level element id. Takes precedence over
+                      elevation_mm if both are provided.
+            elevation_mm: Optional elevation in mm — picks the nearest level.
+                          Used when level_id is not provided.
+            name: Room name (e.g. "Office", "Bathroom"). Default "Room".
+            number: Optional room number. If blank, auto-generated from the
+                    next available integer. If provided but already taken,
+                    the number is made unique (e.g. "101" -> "102", or
+                    "101A" if numeric increment exhausted).
+            upper_limit_id: Optional Level id for the room's upper limit.
+            limit_offset_mm: Optional offset above the upper limit, in mm.
+            base_offset_mm: Optional offset above the base level, in mm.
+                            Default 0.
+            department: Optional Department parameter value.
+            comments: Optional Comments parameter value.
+
+        If both level_id and elevation_mm are omitted, the lowest-elevation
+        level in the project is used.
+
+        Returns the created room's id, unique_id, assigned name/number (may
+        differ from requested if deduped), level info, area (m² and ft²),
+        and perimeter (m and ft).
+
+        Single Ctrl+Z in Revit reverts the creation atomically.
+        """
+        payload = {
+            "x_mm": x_mm,
+            "y_mm": y_mm,
+            "level_id": level_id,
+            "elevation_mm": elevation_mm,
+            "name": name,
+            "number": number,
+            "upper_limit_id": upper_limit_id,
+            "limit_offset_mm": limit_offset_mm,
+            "base_offset_mm": base_offset_mm,
+            "department": department,
+            "comments": comments,
+        }
+        response = await revit_post("/create_room/", payload, ctx)
+        return format_response(response)

--- a/tools/selection_tools.py
+++ b/tools/selection_tools.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Selection MCP tools."""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_selection_tools(mcp, revit_get):
+    """Register selection-management tools."""
+
+    @mcp.tool()
+    async def get_selected_elements(ctx: Context) -> str:
+        """
+        Get information about elements currently selected by the user in Revit.
+
+        Returns id, name, category, type_id, type_name, and level_id (if applicable)
+        for each selected element. If nothing is selected, returns count=0.
+
+        Useful as the first step in any "look at what the user is pointing at then
+        do X" workflow.
+        """
+        response = await revit_get("/selection/", ctx)
+        return format_response(response)

--- a/tools/workset_tools.py
+++ b/tools/workset_tools.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Workset MCP tool -- create user worksets in a workshared Revit model."""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_workset_tools(mcp, revit_get, revit_post):
+    """Register the create_workset tool."""
+
+    @mcp.tool()
+    async def create_workset(
+        name: str,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a user workset in the active Revit model.
+
+        Worksets only exist in workshared models. If the model is not
+        workshared this returns a 'not_workshared' status -- enable
+        worksharing in Revit (Collaborate tab) first; this tool will not
+        enable worksharing for you, since that is a one-way, model-wide change.
+
+        Args:
+            name: Name for the new workset. Must be unique within the project;
+                a duplicate returns a 'name_collision' status with the id of
+                the existing workset.
+
+        To create several worksets, call this once per name.
+        """
+        payload = {"name": name}
+        response = await revit_post("/create_workset/", payload, ctx)
+        return format_response(response)


### PR DESCRIPTION
## Summary

Adds 16 new tools and 4 Revit 2026 compatibility fixes, building on `dd37d46`. Every tool was smoke-tested end-to-end against Revit 2026.

### README-pending tools (`918d9fa`)
Implements the 9 tools the README listed as planned: `get_selected_elements`, `create_line_based_element`, `create_surface_based_element`, `delete_elements`, `modify_element`, `reset_model`, `tag_walls`, `search_modules`, `use_module`. Mutation tools use a defence-in-depth `confirm: bool = False` preview gate.

### New creation tools
- `create_grids_from_walls` — derives a numbered/lettered project grid system from wall centerlines, in a single transaction.
- `create_level` — creates a level (+ optional FloorPlan/CeilingPlan views) in one transaction.
- `create_room` — places a Room at a point; auto-resolves level, auto-dedupes number.
- `create_dimension` — linear dimension between two points, optionally locked to element face references.
- `create_workset` — creates a user workset in a workshared model; returns `not_workshared` / `name_collision` statuses cleanly and never enables worksharing implicitly.

### New analysis / data tools
- `get_material_quantities` — per-material volume/area rollup (m³/m²).
- `ai_element_filter` — structured multi-criteria element finder with rich per-kind output.
- `analyze_model_statistics` — project rollup: counts, categories, types, per-level breakdown.
- `tag_rooms` — bulk RoomTag placement, single transaction.
- `export_room_data` — full per-room parameter export (m²/m³/mm).

### Multi-action element operations
- `operate_element` — one endpoint, ten actions: `select`, `selection_box`, `set_color`, `set_transparency`, `hide`, `unhide`, `temp_hide`, `isolate`, `reset_isolate`, `delete`. Every view-state mutation runs in a transaction (`select` is the only non-transactional action); `delete` is confirm-gated; structured statuses replace thrown exceptions.

### MEP-to-grid dimensioning (`9bbaef0`)
- `dimension_mep_to_grids` — auto-dimensions MEP elements (ducts, cable trays, pipes) to the project grid system in a plan view. Horizontal (E-W) runs are located by Y against the horizontal grids; vertical (N-S) runs by X against the vertical grids. Witness references use `DB.Reference(grid)` (resolves to the grid line) and `DB.Reference(MEPCurve)` (resolves to the centerline); one `NewDimension` call with N coordinate-sorted references builds a continuous (N-1)-segment string. `string_style` is `continuous` (one string per orientation) or `individual` (one grid→run→grid dimension per run, greedily lane-stacked); `grid_scope` is `nearest` or `all`. Runs within `coordinate_tolerance_mm` collapse to one witness; risers and diagonal runs are skipped and reported; the view-visible fallback is capped by `max_elements`. All strings are created in a single transaction.

### Revit 2026 compatibility fixes
Revit 2026's IronPython runtime removed `ElementId.IntegerValue` and changed several Element-base property accessors:
- `d5fe13e` / `8dec946` — `DB.ElementId(int)` now hits an ambiguous Int64 overload; disambiguated via `System.Int64` casts.
- `9f1e015` — `create_room` now detects unplaced \"junk\" rooms in already-occupied enclosures and rolls back cleanly with `area_already_occupied`.
- `f859504` — `ElementType.Name` raises `AttributeError` on Revit 2026; routed through the `DB.Element.Name.__get__()` descriptor.

## Notes
- 39 files changed, ~8.2k insertions across 19 commits. Each commit is self-contained and individually reviewable — happy to split into smaller PRs if maintainers prefer.
- Every tool was smoke-tested on Revit 2026 against real models; each commit message records its own results. The live smoke tests caught and fixed two bugs: `operate_element`'s temp view modes needed a transaction, and `create_workset`'s `Workset.Create` needed one too.
- All additions follow the existing route-module + tool-module + `startup.py` wiring pattern documented in the README.

## Test plan
- [ ] Maintainer review of the route/tool module pattern
- [ ] Verify against a Revit 2025 model (this work was tested on 2026)
- [x] Confirm `confirm`-gate behaviour on mutation tools
- [x] Live-Revit smoke test of `operate_element` (all 10 actions + error paths)
- [x] Live smoke test of `create_workset` (not_workshared / success / name_collision paths)
- [x] Live smoke test of `dimension_mep_to_grids` (continuous + individual modes, both orientations, dry-run; segment values verified exact)