### PR TITLE
Fix format_response: don't error-frame recoverable statuses

### DIFF
--- a/tests/unit/test_format_response.py
+++ b/tests/unit/test_format_response.py
@@ -92,6 +92,107 @@ class TestErrorResponses:
         assert "Code Attempted: print(1)" in result
         assert "Endpoint: /test/" in result
 
+    def test_error_message_fallback_when_no_error_key(self):
+        # An error response carrying only "message" should surface it instead
+        # of the generic "Unknown error occurred" placeholder.
+        result = format_response({"status": "error", "message": "boom"})
+        assert "Error: boom" in result
+        assert "Unknown error occurred" not in result
+
+    def test_unlisted_failure_status_still_error_framed(self):
+        # create_failed is a genuine failure -- NOT a recoverable status.
+        result = format_response(
+            {"status": "create_failed", "error": "Revit returned no element."}
+        )
+        assert "=== ERROR DETAILS ===" in result
+        assert "Error: Revit returned no element." in result
+
+
+class TestRecoverableResponses:
+    """Recoverable statuses are expected, non-error outcomes -- they must not
+    be dressed up with error/traceback framing."""
+
+    def test_empty_result_not_error_framed(self):
+        result = format_response(
+            {
+                "status": "no_rooms_found",
+                "applied_filters": ["level=Level 1"],
+                "skipped_unplaced": 2,
+            }
+        )
+        assert "=== NO ROOMS FOUND ===" in result
+        assert "=== ERROR DETAILS ===" not in result
+        assert "Unknown error occurred" not in result
+
+    def test_recoverable_preserves_structured_data(self):
+        result = format_response(
+            {
+                "status": "no_rooms_found",
+                "applied_filters": ["level=Level 1"],
+                "skipped_unplaced": 2,
+            }
+        )
+        assert "applied_filters" in result
+        assert "skipped_unplaced" in result
+
+    def test_note_read_from_error_key(self):
+        # Some recoverable responses carry their explanation under "error".
+        result = format_response(
+            {
+                "status": "area_already_occupied",
+                "error": "The area is already occupied by another room.",
+                "level_name": "Level 1",
+            }
+        )
+        assert "=== ERROR DETAILS ===" not in result
+        assert "The area is already occupied by another room." in result
+
+    def test_note_read_from_message_key(self):
+        result = format_response(
+            {
+                "status": "no_op",
+                "message": "Nothing to delete in the requested categories.",
+            }
+        )
+        assert "=== ERROR DETAILS ===" not in result
+        assert "Nothing to delete in the requested categories." in result
+
+    def test_preview_status_is_recoverable(self):
+        result = format_response(
+            {
+                "status": "preview",
+                "confirm_required": True,
+                "would_delete_count": 5,
+            }
+        )
+        assert "=== PREVIEW ===" in result
+        assert "=== ERROR DETAILS ===" not in result
+        assert "would_delete_count" in result
+
+    def test_dry_run_status_is_recoverable(self):
+        result = format_response({"status": "dry_run", "planned": 12})
+        assert "=== DRY RUN ===" in result
+        assert "=== ERROR DETAILS ===" not in result
+
+    def test_lookup_miss_is_recoverable(self):
+        result = format_response(
+            {"status": "view_not_found", "error": "View 999 does not exist."}
+        )
+        assert "=== ERROR DETAILS ===" not in result
+        assert "Unknown error occurred" not in result
+        assert "View 999 does not exist." in result
+
+    def test_recoverable_with_details(self):
+        result = format_response(
+            {
+                "status": "view_not_supported",
+                "message": "View is not a plan view.",
+                "details": "Active view type is Section.",
+            }
+        )
+        assert "Details: Active view type is Section." in result
+        assert "=== ERROR DETAILS ===" not in result
+
 
 class TestStringPassthrough:
     def test_string_passthrough(self):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,6 +1,73 @@
 # -*- coding: utf-8 -*-
 """Utility functions for MCP tools"""
 
+import json
+
+
+# Statuses that are valid, expected, recoverable outcomes -- NOT errors.
+#
+# A tool returns one of these when it ran correctly but the result is
+# something other than a plain success: an empty query result, a dry-run or
+# confirm-gate preview, an unmet precondition the caller can fix, or a lookup
+# that did not resolve. They must not be rendered with the
+# "=== ERROR DETAILS ===" / "=== TRACEBACK ===" framing -- that misleads
+# callers into treating a normal branch as a crash, and the generic
+# "Unknown error occurred" fallback discards the structured data these
+# responses carry (applied_filters, existing_rooms_on_level, ...).
+#
+# Only TOP-LEVEL statuses belong here; per-item statuses nested inside a
+# results/preview list (e.g. modify_element's per-parameter "read_only") never
+# reach format_response().
+RECOVERABLE_STATUSES = frozenset({
+    # Preview / dry-run outcomes -- confirm-gate previews and --dry_run runs
+    "preview", "dry_run", "no_op",
+    # Empty-result outcomes -- the tool ran fine, nothing matched the query
+    "no_walls", "no_axis_aligned_walls", "no_references_found",
+    "no_elements_found", "no_rooms_found", "no_rooms_in_view",
+    # Unmet preconditions -- the caller can adjust inputs and retry
+    "not_in_enclosed_area", "area_already_occupied", "name_collision",
+    "view_not_supported", "no_room_tag_family",
+    # Lookup misses -- a supplied id or name did not resolve
+    "view_not_found", "level_not_found", "phase_not_found",
+    # Revit is running but no document is open
+    "active_no_document",
+    # Generic non-error signals
+    "ok", "warning",
+})
+
+
+def _format_recoverable(response):
+    """Render a recoverable, non-error status without alarming error framing.
+
+    See RECOVERABLE_STATUSES. The human-readable note may live under either
+    "message" or "error"; any remaining fields are emitted as a JSON block so
+    callers can still consume the structured data the response carries.
+
+    Args:
+        response: A dict response whose "status" is in RECOVERABLE_STATUSES.
+
+    Returns:
+        str: A neutrally formatted, multi-line summary.
+    """
+    status = response.get("status", "unknown")
+    parts = ["=== {} ===".format(str(status).replace("_", " ").upper())]
+
+    note = response.get("message") or response.get("error") or ""
+    if note:
+        parts.append(note)
+
+    details = response.get("details", "")
+    if details:
+        parts.append("Details: {}".format(details))
+
+    extra = {k: v for k, v in response.items()
+             if k not in ("status", "message", "error", "details")}
+    if extra:
+        parts.append("")
+        parts.append(json.dumps(extra, indent=2, default=str, sort_keys=True))
+
+    return "\n".join(parts)
+
 
 def format_response(response):
     """Helper function to format API responses consistently for MCP tools.
@@ -15,12 +82,12 @@ def format_response(response):
         # Check for different success patterns
         status = response.get("status", "").lower()
         health = response.get("health", "").lower()
-        
+
         # Success conditions: status="success" OR status="active" with health="healthy"
-        is_success = (status == "success" or 
+        is_success = (status == "success" or
                      (status == "active" and health == "healthy") or
                      (status == "active" and "revit_available" in response and response["revit_available"]))
-        
+
         if is_success:
             # For successful responses, return the most relevant data
             if "output" in response:  # Code execution responses
@@ -36,14 +103,14 @@ def format_response(response):
                 status_parts = ["=== REVIT STATUS ==="]
                 status_parts.append("Status: {}".format(response.get("status", "Unknown")))
                 status_parts.append("Health: {}".format(response.get("health", "Unknown")))
-                
+
                 if "api_name" in response:
                     status_parts.append("API: {}".format(response["api_name"]))
                 if "document_title" in response:
                     status_parts.append("Document: {}".format(response["document_title"]))
                 if "revit_available" in response:
                     status_parts.append("Revit Available: {}".format(response["revit_available"]))
-                
+
                 # Add any other fields that might be present
                 known_fields = {"status", "health", "api_name", "document_title", "revit_available"}
                 other_fields = set(response.keys()) - known_fields
@@ -51,43 +118,48 @@ def format_response(response):
                     status_parts.append("")
                     for field in sorted(other_fields):
                         status_parts.append("{}: {}".format(field.replace("_", " ").title(), response[field]))
-                
+
                 return "\n".join(status_parts)
             else:
-                import json
                 return json.dumps(response, indent=2)
+        elif status in RECOVERABLE_STATUSES:
+            # Documented, expected, non-error outcome -- render it neutrally
+            # instead of dressing it up as a crash. See RECOVERABLE_STATUSES.
+            return _format_recoverable(response)
         else:
             # Error case - provide verbose debugging information
-            error_msg = response.get("error", "Unknown error occurred")
+            error_msg = (response.get("error") or
+                         response.get("message") or
+                         "Unknown error occurred")
             traceback_info = response.get("traceback", "")
             details = response.get("details", "")
             status = response.get("status", "unknown")
-            
+
             # Build comprehensive error message
             error_parts = ["=== ERROR DETAILS ==="]
             error_parts.append("Status: {}".format(status))
             error_parts.append("Error: {}".format(error_msg))
-            
+
             if details:
                 error_parts.append("Details: {}".format(details))
-            
+
             if traceback_info:  # Code execution error with traceback
                 error_parts.append("\n=== TRACEBACK ===")
                 error_parts.append(traceback_info)
-            
+
             # Add any additional fields that might be helpful for debugging
             debug_fields = ["code_attempted", "endpoint", "request_data", "response_code"]
             for field in debug_fields:
                 if field in response:
                     error_parts.append("{}: {}".format(field.replace("_", " ").title(), response[field]))
-            
+
             # Include full response for debugging if it has unexpected fields
-            response_keys = set(response.keys()) - {"error", "traceback", "details", "status", "code_attempted", "endpoint", "request_data", "response_code"}
+            response_keys = set(response.keys()) - {"error", "message", "traceback", "details", "status", "code_attempted", "endpoint", "request_data", "response_code"}
             if response_keys:
                 error_parts.append("\n=== ADDITIONAL RESPONSE DATA ===")
                 for key in sorted(response_keys):
                     error_parts.append("{}: {}".format(key, response[key]))
-            
+
             return "\n".join(error_parts)
     else:
         # If response is already a string (error case from _revit_call)


### PR DESCRIPTION
## Summary

`format_response()` in `tools/utils.py` treated **every** response whose status was not `success`/`active` as an error — wrapping it in `=== ERROR DETAILS ===` / `=== TRACEBACK ===` framing and falling back to `Error: Unknown error occurred` when there was no `error` key.

That mislabels documented, expected outcomes as crashes:
- `export_room_data` on a model with no rooms → `status: no_rooms_found`
- `create_room` on an occupied enclosure → `status: area_already_occupied`
- confirm-gate / dry-run tools → `status: preview` / `dry_run`
- a lookup that doesn't resolve → `view_not_found` / `level_not_found`

None of these are errors, and the generic `Unknown error occurred` fallback also discarded the structured data these responses carry (`applied_filters`, `existing_rooms_on_level`, `would_delete_count`, …).

## Changes

- Add `RECOVERABLE_STATUSES` — an allowlist of **top-level** non-error statuses (empty results, previews, unmet preconditions, lookup misses, `active_no_document`). Per-item statuses nested inside a `results`/`preview` list (e.g. `modify_element`'s per-parameter `read_only`) are deliberately excluded since they never reach `format_response()`.
- Route recoverable statuses through `_format_recoverable()`, which renders a neutral `=== STATUS ===` header, the human note (read from either `message` or `error`), and the remaining fields as a JSON block so callers can still consume the carried data.
- The error branch now falls back to `message` before `Unknown error occurred`, so genuine failures that carry only a `message` (e.g. `create_failed`, `invalid_filter`) still read sensibly.

## Test plan

- [x] 10 new tests in `tests/unit/test_format_response.py` (recoverable statuses + error-message fallback + a regression test that an unlisted failure status is *still* error-framed)
- [x] Full unit suite passes — 74 tests