### PR TITLE
Use 127.0.0.1 instead of localhost for pyRevit Routes connection

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,8 +17,8 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
-REVIT_PORT = 48884  # Default pyRevit Routes port
+REVIT_HOST = "127.0.0.1"
+REVIT_PORT = 48884
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 
 


### PR DESCRIPTION
Avoids DNS resolution ambiguity on systems where localhost may resolve to ::1 (IPv6) instead of 127.0.0.1, ensuring the MCP server connects to the correct pyRevit Routes address.