### PR TITLE
fix: use 127.0.0.1 instead of localhost for Revit host

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 


### PR DESCRIPTION
## What changed

`REVIT_HOST` in `main.py` was changed from `"localhost"` to `"127.0.0.1"`.

## Why

On some Windows environments, `localhost` resolves to `::1` (IPv6) rather than `127.0.0.1` (IPv4). The pyRevit Routes server binds exclusively to `127.0.0.1`, so an IPv6 resolution causes the MCP server to fail to connect. Using the explicit IPv4 address ensures a reliable connection regardless of the system's hostname resolution behavior.

## Reviewer notes

No logic changes — purely a hostname string fix. The `BASE_URL` already interpolates `REVIT_HOST`, so it now correctly produces `http://127.0.0.1:48884/revit_mcp`.