### PR TITLE
Use 127.0.0.1 instead of localhost for Revit Routes connection

### DIFF
--- a/MCP Tools.tab/Grids.panel/Crop To View.pushbutton/bundle.yaml
+++ b/MCP Tools.tab/Grids.panel/Crop To View.pushbutton/bundle.yaml
@@ -1,0 +1,8 @@
+title: Crop Grids To View
+tooltip: >
+  Trim grid lines' view-specific extents so they stop exactly at the
+  active view's crop region boundary.
+
+
+  Select one or more grids first to only crop those, or run with nothing
+  selected to crop every grid visible in the active view.

--- a/MCP Tools.tab/Grids.panel/Crop To View.pushbutton/script.py
+++ b/MCP Tools.tab/Grids.panel/Crop To View.pushbutton/script.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+__title__ = "Crop Grids\nTo View"
+__doc__ = (
+    "Trim grid lines' view-specific extents so they stop exactly at the "
+    "active view's crop region boundary.\n\n"
+    "Select one or more grids first to only crop those, or run with nothing "
+    "selected to crop every grid visible in the active view."
+)
+
+from pyrevit import revit, DB, forms
+
+doc = revit.doc
+uidoc = revit.uidoc
+view = doc.ActiveView
+
+
+def clip_line_to_polygon(ax, ay, dx, dy, polygon):
+    """Intersect the infinite line through (ax, ay) with direction (dx, dy)
+    against the polygon's edges. Returns sorted parametric t values.
+    """
+    t_values = []
+    n = len(polygon)
+    for i in range(n):
+        ex0, ey0 = polygon[i]
+        ex1, ey1 = polygon[(i + 1) % n]
+        edx = ex1 - ex0
+        edy = ey1 - ey0
+
+        denom = dx * edy - dy * edx
+        if abs(denom) < 1e-12:
+            continue
+
+        rx = ex0 - ax
+        ry = ey0 - ay
+        s = (dy * rx - dx * ry) / denom
+        if s < -1e-9 or s > 1 + 1e-9:
+            continue
+
+        t = (edy * rx - edx * ry) / denom
+        t_values.append(t)
+
+    return sorted(t_values)
+
+
+if not view.CropBoxActive:
+    forms.alert("The active view has no active crop box/region.", exitscript=True)
+
+mgr = view.GetCropRegionShapeManager()
+loops = list(mgr.GetCropShape())
+polygons = []
+crop_z = None
+for loop in loops:
+    points = []
+    for curve in loop:
+        p0 = curve.GetEndPoint(0)
+        if crop_z is None:
+            crop_z = p0.Z
+        points.append((p0.X, p0.Y))
+    polygons.append(points)
+
+if not polygons:
+    forms.alert("Could not resolve a crop region shape for this view.", exitscript=True)
+
+selected_ids = uidoc.Selection.GetElementIds()
+grids = [doc.GetElement(eid) for eid in selected_ids if isinstance(doc.GetElement(eid), DB.Grid)]
+
+if not grids:
+    grids = list(DB.FilteredElementCollector(doc, view.Id).OfClass(DB.Grid))
+
+if not grids:
+    forms.alert("No grids selected or visible in this view.", exitscript=True)
+
+cropped = 0
+errors = []
+with revit.Transaction("Crop Grids To View"):
+    for grid in grids:
+        curve = grid.Curve
+        p0 = curve.GetEndPoint(0)
+        p1 = curve.GetEndPoint(1)
+        dx = p1.X - p0.X
+        dy = p1.Y - p0.Y
+
+        all_t = []
+        for polygon in polygons:
+            all_t.extend(clip_line_to_polygon(p0.X, p0.Y, dx, dy, polygon))
+
+        if len(all_t) < 2:
+            errors.append("Grid {}: does not cross the crop region".format(grid.Name))
+            continue
+
+        t_min = min(all_t)
+        t_max = max(all_t)
+
+        # Use the Z Revit already expects for this view's in-view curves
+        # (not the crop shape's Z), otherwise SetCurveInView rejects the
+        # curve as not coincident with the grid's datum plane.
+        existing_inview = list(
+            grid.GetCurvesInView(DB.DatumExtentType.ViewSpecific, view)
+        )
+        inview_z = existing_inview[0].GetEndPoint(0).Z if existing_inview else p0.Z
+
+        new_p0 = DB.XYZ(p0.X + t_min * dx, p0.Y + t_min * dy, inview_z)
+        new_p1 = DB.XYZ(p0.X + t_max * dx, p0.Y + t_max * dy, inview_z)
+
+        try:
+            new_curve = DB.Line.CreateBound(new_p0, new_p1)
+            grid.SetCurveInView(DB.DatumExtentType.ViewSpecific, view, new_curve)
+            cropped += 1
+        except Exception as set_err:
+            errors.append("Grid {}: {}".format(grid.Name, set_err))
+
+message = "Cropped {} grid(s) to the view's crop region.".format(cropped)
+if errors:
+    message += "\n\nErrors:\n" + "\n".join(errors)
+
+forms.alert(message)

--- a/MCP Tools.tab/Toposolid.panel/Align Points.pushbutton/bundle.yaml
+++ b/MCP Tools.tab/Toposolid.panel/Align Points.pushbutton/bundle.yaml
@@ -1,0 +1,8 @@
+title: Align Points
+tooltip: >
+  Snap selected Toposolid edit points that are within a tolerance of
+  selected detail/model lines onto those lines, in plan (X/Y) only.
+  Point elevation (Z) is never changed.
+
+
+  Select a Toposolid plus one or more lines, then run this tool.

--- a/MCP Tools.tab/Toposolid.panel/Align Points.pushbutton/script.py
+++ b/MCP Tools.tab/Toposolid.panel/Align Points.pushbutton/script.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+__title__ = "Align\nPoints"
+__doc__ = (
+    "Snap selected Toposolid edit points that are within a tolerance of "
+    "selected detail/model lines onto those lines, in plan (X/Y) only. "
+    "Point elevation (Z) is never changed.\n\n"
+    "Select a Toposolid plus one or more lines, then run this tool."
+)
+
+from pyrevit import revit, DB, forms
+import math
+
+doc = revit.doc
+uidoc = revit.uidoc
+
+DEFAULT_TOLERANCE_MM = "50"
+MM_TO_FEET = 1.0 / 304.8
+FEET_TO_M = 0.3048
+DEFAULT_HEIGHT_TOLERANCE_M = 0.01
+
+
+def perpendicular_foot_on_segment(px, py, x1, y1, x2, y2):
+    """Foot of the perpendicular from (px, py) onto the line through
+    (x1,y1)-(x2,y2), in plan. Returns None if that foot falls outside the
+    bound segment - the point must NOT be snapped to an endpoint in that case.
+    """
+    dx = x2 - x1
+    dy = y2 - y1
+    length_sq = dx * dx + dy * dy
+    if length_sq == 0:
+        return None
+    t = ((px - x1) * dx + (py - y1) * dy) / length_sq
+    if t < 0.0 or t > 1.0:
+        return None
+    return x1 + t * dx, y1 + t * dy
+
+
+selected_ids = uidoc.Selection.GetElementIds()
+selected_elems = [doc.GetElement(eid) for eid in selected_ids]
+
+toposolids = [e for e in selected_elems if isinstance(e, DB.Toposolid)]
+lines = [
+    e
+    for e in selected_elems
+    if isinstance(e, (DB.DetailLine, DB.ModelLine, DB.DetailCurve, DB.ModelCurve))
+]
+
+if not toposolids:
+    forms.alert("Select a Toposolid (plus one or more lines) first.", exitscript=True)
+if not lines:
+    forms.alert(
+        "Select one or more detail/model lines (plus the Toposolid) first.",
+        exitscript=True,
+    )
+
+tolerance_str = forms.ask_for_string(
+    default=DEFAULT_TOLERANCE_MM,
+    prompt="Snap tolerance (mm):",
+    title="Align Toposolid Points",
+)
+if not tolerance_str:
+    import sys
+
+    sys.exit()
+
+try:
+    tolerance_mm = float(tolerance_str.replace(",", "."))
+except ValueError:
+    forms.alert("Invalid tolerance value.", exitscript=True)
+
+tolerance_ft = tolerance_mm * MM_TO_FEET
+
+height_str = forms.ask_for_string(
+    default="",
+    prompt="Only move points at this height in meters (leave blank for any height):",
+    title="Align Toposolid Points",
+)
+
+target_height_m = None
+if height_str and height_str.strip():
+    try:
+        target_height_m = float(height_str.replace(",", "."))
+    except ValueError:
+        forms.alert("Invalid height value.", exitscript=True)
+
+segments = []
+for ln in lines:
+    curve = getattr(ln, "GeometryCurve", None)
+    if curve is None:
+        loc = ln.Location
+        curve = loc.Curve if loc else None
+    if curve is None:
+        continue
+    p0 = curve.GetEndPoint(0)
+    p1 = curve.GetEndPoint(1)
+    segments.append((p0.X, p0.Y, p1.X, p1.Y))
+
+if not segments:
+    forms.alert("None of the selected lines have usable geometry.", exitscript=True)
+
+total_moved = 0
+with revit.Transaction("Align Toposolid Points to Lines"):
+    for topo in toposolids:
+        editor = topo.GetSlabShapeEditor()
+        if editor is None or not editor.IsEnabled:
+            continue
+
+        vertices = list(editor.SlabShapeVertices)
+        to_delete = []
+        to_add = []
+
+        for v in vertices:
+            # Skip the toposolid's boundary - only Interior points are
+            # eligible to move, never Corner/Edge vertices.
+            if v.VertexType != DB.SlabShapeVertexType.Interior:
+                continue
+
+            p = v.Position
+
+            if target_height_m is not None:
+                point_height_m = p.Z * FEET_TO_M
+                if abs(point_height_m - target_height_m) > DEFAULT_HEIGHT_TOLERANCE_M:
+                    continue
+
+            best_dist = tolerance_ft
+            best_xy = None
+            for (x1, y1, x2, y2) in segments:
+                foot = perpendicular_foot_on_segment(p.X, p.Y, x1, y1, x2, y2)
+                if foot is None:
+                    continue
+                cx, cy = foot
+                dist = math.hypot(p.X - cx, p.Y - cy)
+                if dist <= best_dist:
+                    best_dist = dist
+                    best_xy = (cx, cy)
+            if best_xy is not None:
+                to_delete.append(v)
+                to_add.append(DB.XYZ(best_xy[0], best_xy[1], p.Z))
+
+        # SlabShapeEditor has no direct "move vertex in plan" call, so move by
+        # deleting the old vertex and adding a new one at the snapped X/Y with
+        # the original Z preserved.
+        for v in to_delete:
+            editor.DeletePoint(v)
+        for new_point in to_add:
+            editor.AddPoint(new_point)
+
+        total_moved += len(to_add)
+
+forms.alert("Moved {} toposolid point(s) onto the selected line(s).".format(total_moved))

--- a/MCP Tools.tab/Toposolid.panel/Subdivide From Region.pushbutton/bundle.yaml
+++ b/MCP Tools.tab/Toposolid.panel/Subdivide From Region.pushbutton/bundle.yaml
@@ -1,0 +1,8 @@
+title: Subdivide From Region
+tooltip: >
+  Create a Toposolid subdivision shaped by one or more Filled Region
+  boundaries.
+
+
+  Select a Toposolid plus one or more Filled Regions, then run this tool.
+  You'll be asked which Toposolid type to use for the new subdivision(s).

--- a/MCP Tools.tab/Toposolid.panel/Subdivide From Region.pushbutton/script.py
+++ b/MCP Tools.tab/Toposolid.panel/Subdivide From Region.pushbutton/script.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+__title__ = "Subdivide\nFrom Region"
+__doc__ = (
+    "Create a Toposolid subdivision shaped by one or more Filled Region "
+    "boundaries.\n\n"
+    "Select a Toposolid plus one or more Filled Regions, then run this tool. "
+    "You'll be asked which Toposolid type to use for the new subdivision(s)."
+)
+
+from pyrevit import revit, DB, forms
+from System.Collections.Generic import List
+
+doc = revit.doc
+uidoc = revit.uidoc
+
+SAME_AS_HOST = "<Same as host toposolid>"
+
+selected_ids = uidoc.Selection.GetElementIds()
+selected_elems = [doc.GetElement(eid) for eid in selected_ids]
+
+toposolids = [e for e in selected_elems if isinstance(e, DB.Toposolid)]
+filled_regions = [e for e in selected_elems if isinstance(e, DB.FilledRegion)]
+
+if not toposolids:
+    forms.alert(
+        "Select a Toposolid (plus one or more Filled Regions) first.",
+        exitscript=True,
+    )
+if not filled_regions:
+    forms.alert(
+        "Select one or more Filled Regions (plus the Toposolid) first.",
+        exitscript=True,
+    )
+
+host = toposolids[0]
+
+topo_types = list(DB.FilteredElementCollector(doc).OfClass(DB.ToposolidType))
+type_names_by_id = {}
+for tt in topo_types:
+    name_param = tt.get_Parameter(DB.BuiltInParameter.ALL_MODEL_TYPE_NAME)
+    name = name_param.AsString() if name_param else None
+    if name:
+        type_names_by_id[name] = tt.Id
+
+options = [SAME_AS_HOST] + sorted(type_names_by_id.keys())
+
+chosen_name = forms.SelectFromList.show(
+    options,
+    title="Choose Toposolid Type for Subdivision",
+    button_name="Create Subdivision",
+)
+
+if not chosen_name:
+    import sys
+
+    sys.exit()
+
+target_type_id = None
+if chosen_name != SAME_AS_HOST:
+    target_type_id = type_names_by_id[chosen_name]
+
+created = 0
+errors = []
+with revit.Transaction("Create Toposolid Subdivision From Filled Region"):
+    for fr in filled_regions:
+        loops = list(fr.GetBoundaries())
+        if not loops:
+            errors.append("Filled region {} has no boundary loops".format(fr.Id))
+            continue
+
+        profiles = List[DB.CurveLoop](loops)
+
+        try:
+            if target_type_id is not None:
+                host.CreateSubDivision(doc, target_type_id, profiles)
+            else:
+                host.CreateSubDivision(doc, profiles)
+            created += 1
+        except Exception as create_err:
+            errors.append("Filled region {}: {}".format(fr.Id, create_err))
+
+message = "Created {} subdivision(s).".format(created)
+if errors:
+    message += "\n\nErrors:\n" + "\n".join(errors)
+
+forms.alert(message)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 

--- a/revit_mcp/grid_tools.py
+++ b/revit_mcp/grid_tools.py
@@ -1,0 +1,235 @@
+# -*- coding: UTF-8 -*-
+"""
+Grid Tools Module for Revit MCP
+Trims grid lines' view-specific extents to a view's crop region boundary.
+"""
+
+from pyrevit import routes, DB
+from utils import element_id_value
+from System import Int64
+import json
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def _element_id(value):
+    """Build an ElementId from a plain int, disambiguating the overload."""
+    return DB.ElementId(Int64(value))
+
+
+def _crop_polygon_xy(view):
+    """Flatten the view's crop region shape into a list of (x, y) polygons
+    (one list of points per loop), plus the constant Z of the crop curves.
+    """
+    mgr = view.GetCropRegionShapeManager()
+    loops = list(mgr.GetCropShape())
+    polygons = []
+    z = None
+    for loop in loops:
+        points = []
+        for curve in loop:
+            p0 = curve.GetEndPoint(0)
+            if z is None:
+                z = p0.Z
+            points.append((p0.X, p0.Y))
+        polygons.append(points)
+    return polygons, z
+
+
+def _clip_line_to_polygon(ax, ay, dx, dy, polygon):
+    """Intersect the infinite line through (ax, ay) with direction (dx, dy)
+    against the polygon's edges (list of (x, y) vertices, closed loop).
+    Returns a sorted list of parametric t values (along the direction,
+    unnormalized) where the line crosses an edge.
+    """
+    t_values = []
+    n = len(polygon)
+    for i in range(n):
+        ex0, ey0 = polygon[i]
+        ex1, ey1 = polygon[(i + 1) % n]
+        edx = ex1 - ex0
+        edy = ey1 - ey0
+
+        # Solve A + t*D = E0 + s*Ed, i.e. t*D - s*Ed = E0 - A
+        denom = dx * edy - dy * edx
+        if abs(denom) < 1e-12:
+            continue  # parallel
+
+        rx = ex0 - ax
+        ry = ey0 - ay
+        s = (dy * rx - dx * ry) / denom
+        if s < -1e-9 or s > 1 + 1e-9:
+            continue  # intersection outside this edge segment
+
+        t = (edy * rx - edx * ry) / denom
+        t_values.append(t)
+
+    return sorted(t_values)
+
+
+def register_grid_tools_routes(api):
+    """Register grid-related routes with the API"""
+
+    @api.route("/crop_grids_to_view/", methods=["POST"])
+    def crop_grids_to_view(doc, uidoc, request):
+        """
+        Trim grid lines' view-specific extents so they stop exactly at the
+        active (or specified) view's crop region boundary.
+
+        Expected payload:
+        {
+            "view_id": 123456,       # optional; defaults to the active view
+            "grid_ids": [111, 222],  # optional; defaults to current selection,
+                                      # then to all grids visible in the view
+            "margin_mm": 0.0         # optional; positive extends past the crop
+                                      # edge, negative insets from it
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = {}
+            if request and request.data:
+                data = (
+                    json.loads(request.data)
+                    if isinstance(request.data, str)
+                    else request.data
+                )
+
+            view_id = data.get("view_id")
+            grid_ids = data.get("grid_ids")
+            margin_mm = float(data.get("margin_mm", 0.0))
+            margin_ft = margin_mm * MM_TO_FEET
+
+            view = doc.GetElement(_element_id(view_id)) if view_id else doc.ActiveView
+            if not isinstance(view, DB.View):
+                return routes.make_response(
+                    data={"error": "view_id does not refer to a View"}, status=400
+                )
+
+            if not view.CropBoxActive:
+                return routes.make_response(
+                    data={"error": "View has no active crop box/region"}, status=400
+                )
+
+            if not grid_ids and uidoc:
+                selected_ids = list(uidoc.Selection.GetElementIds())
+                grid_ids = [
+                    element_id_value(eid)
+                    for eid in selected_ids
+                    if isinstance(doc.GetElement(eid), DB.Grid)
+                ]
+
+            if not grid_ids:
+                grids = list(
+                    DB.FilteredElementCollector(doc, view.Id).OfClass(DB.Grid)
+                )
+                grid_ids = [element_id_value(g.Id) for g in grids]
+
+            if not grid_ids:
+                return routes.make_response(
+                    data={"error": "No grids specified, selected, or visible in the view"},
+                    status=400,
+                )
+
+            polygons, crop_z = _crop_polygon_xy(view)
+            if not polygons:
+                return routes.make_response(
+                    data={"error": "Could not resolve a crop region shape for the view"},
+                    status=400,
+                )
+
+            results = []
+            t = DB.Transaction(doc, "Crop grids to view via MCP")
+            t.Start()
+            try:
+                for gid in grid_ids:
+                    grid = doc.GetElement(_element_id(gid))
+                    if not isinstance(grid, DB.Grid):
+                        results.append({"grid_id": gid, "error": "Element is not a Grid"})
+                        continue
+
+                    curve = grid.Curve
+                    p0 = curve.GetEndPoint(0)
+                    p1 = curve.GetEndPoint(1)
+                    dx = p1.X - p0.X
+                    dy = p1.Y - p0.Y
+
+                    all_t = []
+                    for polygon in polygons:
+                        all_t.extend(
+                            _clip_line_to_polygon(p0.X, p0.Y, dx, dy, polygon)
+                        )
+
+                    if len(all_t) < 2:
+                        results.append({
+                            "grid_id": gid,
+                            "error": "Grid does not cross the view's crop region",
+                        })
+                        continue
+
+                    t_min = min(all_t) - margin_ft
+                    t_max = max(all_t) + margin_ft
+
+                    # Use the Z Revit already expects for this view's
+                    # in-view curves (not the crop shape's Z) - otherwise
+                    # SetCurveInView rejects the curve as not coincident
+                    # with the grid's datum plane.
+                    existing_inview = list(
+                        grid.GetCurvesInView(DB.DatumExtentType.ViewSpecific, view)
+                    )
+                    inview_z = (
+                        existing_inview[0].GetEndPoint(0).Z
+                        if existing_inview
+                        else p0.Z
+                    )
+
+                    new_p0 = DB.XYZ(p0.X + t_min * dx, p0.Y + t_min * dy, inview_z)
+                    new_p1 = DB.XYZ(p0.X + t_max * dx, p0.Y + t_max * dy, inview_z)
+
+                    try:
+                        new_curve = DB.Line.CreateBound(new_p0, new_p1)
+                        grid.SetCurveInView(
+                            DB.DatumExtentType.ViewSpecific, view, new_curve
+                        )
+                    except Exception as set_err:
+                        results.append({"grid_id": gid, "error": str(set_err)})
+                        continue
+
+                    results.append({
+                        "grid_id": gid,
+                        "status": "success",
+                        "new_extent": {
+                            "from": {"x": new_p0.X, "y": new_p0.Y},
+                            "to": {"x": new_p1.X, "y": new_p1.Y},
+                        },
+                    })
+
+                t.Commit()
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+            return routes.make_response(data={
+                "status": "success",
+                "view_id": element_id_value(view.Id),
+                "margin_mm": margin_mm,
+                "results": results,
+            })
+
+        except Exception as e:
+            logger.error("Failed to crop grids to view: {}".format(str(e)))
+            return routes.make_response(
+                data={"error": str(e), "traceback": traceback.format_exc()},
+                status=500,
+            )
+
+    logger.info("Grid tools routes registered successfully")

--- a/revit_mcp/topo_tools.py
+++ b/revit_mcp/topo_tools.py
@@ -1,0 +1,410 @@
+# -*- coding: UTF-8 -*-
+"""
+Toposolid Tools Module for Revit MCP
+Aligns toposolid edit points to nearby detail/model lines in plan (XY only),
+leaving each point's elevation (Z) untouched.
+"""
+
+from pyrevit import routes, DB
+from utils import element_id_value
+from System import Int64
+import json
+import logging
+import math
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+def _element_id(value):
+    """Build an ElementId from a plain int, disambiguating the overload."""
+    return DB.ElementId(Int64(value))
+
+# Default snap tolerance in millimeters
+DEFAULT_TOLERANCE_MM = 50.0
+MM_TO_FEET = 1.0 / 304.8
+FEET_TO_M = 0.3048
+
+# Default tolerance for matching a point's elevation against target_height_m
+DEFAULT_HEIGHT_TOLERANCE_M = 0.01
+
+
+def _perpendicular_foot_on_segment(px, py, x1, y1, x2, y2):
+    """Foot of the perpendicular from (px, py) onto the line through
+    (x1,y1)-(x2,y2), in plan. Returns None if that foot falls outside the
+    bound segment (i.e. the point doesn't meet the line perpendicularly
+    within its extent) - it must NOT be snapped to an endpoint in that case.
+    """
+    dx = x2 - x1
+    dy = y2 - y1
+    length_sq = dx * dx + dy * dy
+    if length_sq == 0:
+        return None
+    t = ((px - x1) * dx + (py - y1) * dy) / length_sq
+    if t < 0.0 or t > 1.0:
+        return None
+    return x1 + t * dx, y1 + t * dy
+
+
+def _line_segments_xy(doc, line_ids):
+    """Resolve line-like element ids to a flat list of (x1, y1, x2, y2) plan segments."""
+    segments = []
+    skipped = []
+    for lid in line_ids:
+        elem = doc.GetElement(_element_id(lid))
+        if elem is None:
+            skipped.append({"id": lid, "reason": "not found"})
+            continue
+        curve = None
+        try:
+            curve = elem.GeometryCurve
+        except AttributeError:
+            try:
+                loc = elem.Location
+                curve = loc.Curve if loc else None
+            except AttributeError:
+                curve = None
+        if curve is None:
+            skipped.append({"id": lid, "reason": "no curve geometry"})
+            continue
+        try:
+            p0 = curve.GetEndPoint(0)
+            p1 = curve.GetEndPoint(1)
+            segments.append((p0.X, p0.Y, p1.X, p1.Y))
+        except Exception as curve_err:
+            skipped.append({"id": lid, "reason": str(curve_err)})
+    return segments, skipped
+
+
+def register_topo_tools_routes(api):
+    """Register toposolid-related routes with the API"""
+
+    @api.route("/align_toposolid_points/", methods=["POST"])
+    def align_toposolid_points(doc, uidoc, request):
+        """
+        Snap toposolid edit points that fall within a tolerance of one or more
+        lines (detail lines, model lines, etc.) onto those lines in plan (X/Y).
+        Point elevation (Z) is never modified.
+
+        Expected payload:
+        {
+            "toposolid_ids": [123456],       # optional; falls back to selection
+            "line_ids": [111, 222],          # optional; falls back to selection
+            "tolerance_mm": 50.0,            # optional; default 50mm
+            "target_height_m": 15.0,         # optional; only move points at this elevation
+            "height_tolerance_m": 0.01       # optional; default 1cm match window
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = {}
+            if request and request.data:
+                data = (
+                    json.loads(request.data)
+                    if isinstance(request.data, str)
+                    else request.data
+                )
+
+            toposolid_ids = data.get("toposolid_ids")
+            line_ids = data.get("line_ids")
+            tolerance_mm = float(data.get("tolerance_mm", DEFAULT_TOLERANCE_MM))
+            tolerance_ft = tolerance_mm * MM_TO_FEET
+
+            target_height_m = data.get("target_height_m")
+            if target_height_m is not None:
+                target_height_m = float(target_height_m)
+            height_tolerance_m = float(
+                data.get("height_tolerance_m", DEFAULT_HEIGHT_TOLERANCE_M)
+            )
+
+            # Fall back to current UI selection for whichever side wasn't provided
+            if not toposolid_ids or not line_ids:
+                selected_ids = list(uidoc.Selection.GetElementIds()) if uidoc else []
+                selected_elems = [doc.GetElement(eid) for eid in selected_ids]
+
+                if not toposolid_ids:
+                    toposolid_ids = [
+                        element_id_value(e.Id)
+                        for e in selected_elems
+                        if isinstance(e, DB.Toposolid)
+                    ]
+                if not line_ids:
+                    line_ids = [
+                        element_id_value(e.Id)
+                        for e in selected_elems
+                        if isinstance(e, (DB.DetailLine, DB.ModelLine, DB.DetailCurve, DB.ModelCurve))
+                    ]
+
+            if not toposolid_ids:
+                return routes.make_response(
+                    data={"error": "No toposolid specified or selected"}, status=400
+                )
+            if not line_ids:
+                return routes.make_response(
+                    data={"error": "No lines specified or selected"}, status=400
+                )
+
+            segments, skipped_lines = _line_segments_xy(doc, line_ids)
+            if not segments:
+                return routes.make_response(
+                    data={"error": "None of the provided lines had usable geometry",
+                          "skipped_lines": skipped_lines},
+                    status=400,
+                )
+
+            results = []
+            t = DB.Transaction(doc, "Align toposolid points to lines via MCP")
+            t.Start()
+            try:
+                for topo_id in toposolid_ids:
+                    topo = doc.GetElement(_element_id(topo_id))
+                    if not isinstance(topo, DB.Toposolid):
+                        results.append({
+                            "toposolid_id": topo_id,
+                            "error": "Element is not a Toposolid",
+                        })
+                        continue
+
+                    editor = topo.GetSlabShapeEditor()
+                    if editor is None or not editor.IsEnabled:
+                        results.append({
+                            "toposolid_id": topo_id,
+                            "error": "Toposolid has no editable shape (SlabShapeEditor unavailable)",
+                        })
+                        continue
+
+                    vertices = list(editor.SlabShapeVertices)
+                    to_delete = []
+                    to_add = []
+                    moved = []
+
+                    for v in vertices:
+                        # Skip the toposolid's boundary - only Interior points
+                        # are eligible to move, never Corner/Edge vertices.
+                        if v.VertexType != DB.SlabShapeVertexType.Interior:
+                            continue
+
+                        p = v.Position
+
+                        if target_height_m is not None:
+                            point_height_m = p.Z * FEET_TO_M
+                            if abs(point_height_m - target_height_m) > height_tolerance_m:
+                                continue
+
+                        best_dist = tolerance_ft
+                        best_xy = None
+                        for (x1, y1, x2, y2) in segments:
+                            foot = _perpendicular_foot_on_segment(p.X, p.Y, x1, y1, x2, y2)
+                            if foot is None:
+                                continue
+                            cx, cy = foot
+                            dist = math.hypot(p.X - cx, p.Y - cy)
+                            if dist <= best_dist:
+                                best_dist = dist
+                                best_xy = (cx, cy)
+
+                        if best_xy is not None:
+                            new_point = DB.XYZ(best_xy[0], best_xy[1], p.Z)
+                            to_delete.append(v)
+                            to_add.append(new_point)
+                            moved.append({
+                                "from": {"x": p.X, "y": p.Y, "z": p.Z},
+                                "to": {"x": new_point.X, "y": new_point.Y, "z": new_point.Z},
+                                "distance_mm": best_dist / MM_TO_FEET,
+                            })
+
+                    # Move each vertex by deleting it and re-adding at the snapped
+                    # X/Y with its original Z (SlabShapeEditor has no direct
+                    # "move vertex in plan" call - ModifySubElement only adjusts
+                    # elevation, not X/Y).
+                    for v in to_delete:
+                        editor.DeletePoint(v)
+                    for new_point in to_add:
+                        editor.AddPoint(new_point)
+
+                    results.append({
+                        "toposolid_id": topo_id,
+                        "total_points": len(vertices),
+                        "points_moved": len(moved),
+                        "moved": moved,
+                    })
+
+                t.Commit()
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+            return routes.make_response(data={
+                "status": "success",
+                "tolerance_mm": tolerance_mm,
+                "target_height_m": target_height_m,
+                "height_tolerance_m": height_tolerance_m,
+                "line_ids_used": line_ids,
+                "skipped_lines": skipped_lines,
+                "results": results,
+            })
+
+        except Exception as e:
+            logger.error("Failed to align toposolid points: {}".format(str(e)))
+            return routes.make_response(
+                data={"error": str(e), "traceback": traceback.format_exc()},
+                status=500,
+            )
+
+    @api.route("/create_toposolid_subdivision/", methods=["POST"])
+    def create_toposolid_subdivision(doc, uidoc, request):
+        """
+        Create a Toposolid subdivision using one or more Filled Regions as the
+        subdivision boundary/boundaries.
+
+        Expected payload:
+        {
+            "toposolid_id": 123456,            # optional; falls back to selection
+            "filled_region_ids": [111, 222],   # optional; falls back to selection
+            "type_name": "Some Toposolid Type" # optional; defaults to host's type
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = {}
+            if request and request.data:
+                data = (
+                    json.loads(request.data)
+                    if isinstance(request.data, str)
+                    else request.data
+                )
+
+            toposolid_id = data.get("toposolid_id")
+            filled_region_ids = data.get("filled_region_ids")
+            type_name = data.get("type_name")
+
+            # Fall back to current UI selection for whichever side wasn't provided
+            if not toposolid_id or not filled_region_ids:
+                selected_ids = list(uidoc.Selection.GetElementIds()) if uidoc else []
+                selected_elems = [doc.GetElement(eid) for eid in selected_ids]
+
+                if not toposolid_id:
+                    topo_candidates = [
+                        e for e in selected_elems if isinstance(e, DB.Toposolid)
+                    ]
+                    if topo_candidates:
+                        toposolid_id = element_id_value(topo_candidates[0].Id)
+
+                if not filled_region_ids:
+                    filled_region_ids = [
+                        element_id_value(e.Id)
+                        for e in selected_elems
+                        if isinstance(e, DB.FilledRegion)
+                    ]
+
+            if not toposolid_id:
+                return routes.make_response(
+                    data={"error": "No host toposolid specified or selected"},
+                    status=400,
+                )
+            if not filled_region_ids:
+                return routes.make_response(
+                    data={"error": "No filled regions specified or selected"},
+                    status=400,
+                )
+
+            host = doc.GetElement(_element_id(toposolid_id))
+            if not isinstance(host, DB.Toposolid):
+                return routes.make_response(
+                    data={"error": "toposolid_id does not refer to a Toposolid"},
+                    status=400,
+                )
+
+            target_type_id = None
+            if type_name:
+                topo_types = DB.FilteredElementCollector(doc).OfClass(
+                    DB.ToposolidType
+                )
+                for tt in topo_types:
+                    name_param = tt.get_Parameter(
+                        DB.BuiltInParameter.ALL_MODEL_TYPE_NAME
+                    )
+                    if name_param and name_param.AsString() == type_name:
+                        target_type_id = tt.Id
+                        break
+                if target_type_id is None:
+                    return routes.make_response(
+                        data={"error": "Toposolid type not found: {}".format(type_name)},
+                        status=404,
+                    )
+
+            results = []
+            t = DB.Transaction(doc, "Create toposolid subdivision via MCP")
+            t.Start()
+            try:
+                for fr_id in filled_region_ids:
+                    fr = doc.GetElement(_element_id(fr_id))
+                    if not isinstance(fr, DB.FilledRegion):
+                        results.append({
+                            "filled_region_id": fr_id,
+                            "error": "Element is not a FilledRegion",
+                        })
+                        continue
+
+                    loops = list(fr.GetBoundaries())
+                    if not loops:
+                        results.append({
+                            "filled_region_id": fr_id,
+                            "error": "Filled region has no boundary loops",
+                        })
+                        continue
+
+                    from System.Collections.Generic import List
+
+                    profiles = List[DB.CurveLoop](loops)
+
+                    try:
+                        if target_type_id is not None:
+                            subdivision = host.CreateSubDivision(
+                                doc, target_type_id, profiles
+                            )
+                        else:
+                            subdivision = host.CreateSubDivision(doc, profiles)
+                    except Exception as create_err:
+                        results.append({
+                            "filled_region_id": fr_id,
+                            "error": str(create_err),
+                        })
+                        continue
+
+                    results.append({
+                        "filled_region_id": fr_id,
+                        "subdivision_id": element_id_value(subdivision.Id),
+                        "status": "success",
+                    })
+
+                t.Commit()
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+            return routes.make_response(data={
+                "status": "success",
+                "toposolid_id": toposolid_id,
+                "type_name": type_name,
+                "results": results,
+            })
+
+        except Exception as e:
+            logger.error("Failed to create toposolid subdivision: {}".format(str(e)))
+            return routes.make_response(
+                data={"error": str(e), "traceback": traceback.format_exc()},
+                status=500,
+            )
+
+    logger.info("Toposolid tools routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -45,6 +45,14 @@ def register_routes():
 
         register_document_routes(api)
 
+        from revit_mcp.topo_tools import register_topo_tools_routes
+
+        register_topo_tools_routes(api)
+
+        from revit_mcp.grid_tools import register_grid_tools_routes
+
+        register_grid_tools_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,6 +13,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .code_execution_tools import register_code_execution_tools
     from .launch_tools import register_launch_tools
     from .document_tools import register_document_tools
+    from .topo_tools import register_topo_tools
+    from .grid_tools import register_grid_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -25,3 +27,5 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     )
     register_launch_tools(mcp_server, revit_get_func)
     register_document_tools(mcp_server, revit_get_func, revit_post_func)
+    register_topo_tools(mcp_server, revit_post_func)
+    register_grid_tools(mcp_server, revit_post_func)

--- a/tools/grid_tools.py
+++ b/tools/grid_tools.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Grid editing tools"""
+
+from mcp.server.fastmcp import Context
+from typing import List, Optional
+from .utils import format_response
+
+
+def register_grid_tools(mcp, revit_post):
+    """Register grid-related tools"""
+
+    @mcp.tool()
+    async def crop_grids_to_view(
+        view_id: Optional[int] = None,
+        grid_ids: Optional[List[int]] = None,
+        margin_mm: float = 0.0,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Trim grid lines' view-specific extents so they stop exactly at the
+        view's crop region boundary, instead of extending past it.
+
+        If view_id is omitted, the active view is used. If grid_ids is
+        omitted, the current selection is used, falling back to every grid
+        visible in the view.
+
+        margin_mm: positive extends the trimmed grid line slightly past the
+        crop edge, negative insets it from the edge. Default 0 (exact cut).
+        """
+        data = {
+            "view_id": view_id,
+            "grid_ids": grid_ids,
+            "margin_mm": margin_mm,
+        }
+        response = await revit_post("/crop_grids_to_view/", data, ctx)
+        return format_response(response)

--- a/tools/topo_tools.py
+++ b/tools/topo_tools.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Toposolid editing tools"""
+
+from mcp.server.fastmcp import Context
+from typing import List, Optional
+from .utils import format_response
+
+
+def register_topo_tools(mcp, revit_post):
+    """Register toposolid-related tools"""
+
+    @mcp.tool()
+    async def align_toposolid_points(
+        toposolid_ids: Optional[List[int]] = None,
+        line_ids: Optional[List[int]] = None,
+        tolerance_mm: float = 50.0,
+        target_height_m: Optional[float] = None,
+        height_tolerance_m: float = 0.01,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Snap toposolid edit points that are within `tolerance_mm` of one or more
+        detail/model lines onto those lines, in plan (X/Y) only. Point elevation
+        (Z) is never changed.
+
+        If target_height_m is given, only points whose elevation is within
+        height_tolerance_m of that value (default 1cm window) are considered.
+
+        If toposolid_ids and/or line_ids are omitted, the current Revit selection
+        is used to fill in whichever side is missing (toposolids and lines can be
+        selected together).
+        """
+        data = {
+            "toposolid_ids": toposolid_ids,
+            "line_ids": line_ids,
+            "tolerance_mm": tolerance_mm,
+            "target_height_m": target_height_m,
+            "height_tolerance_m": height_tolerance_m,
+        }
+        response = await revit_post("/align_toposolid_points/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_toposolid_subdivision(
+        toposolid_id: Optional[int] = None,
+        filled_region_ids: Optional[List[int]] = None,
+        type_name: Optional[str] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a Toposolid subdivision shaped by one or more Filled Region
+        boundaries. One subdivision is created per filled region.
+
+        If type_name is omitted, each subdivision keeps the host toposolid's
+        type/material. If given, the subdivision is created with that
+        toposolid type instead.
+
+        If toposolid_id and/or filled_region_ids are omitted, the current
+        Revit selection is used to fill in whichever side is missing (select
+        the host toposolid plus one or more filled regions together).
+        """
+        data = {
+            "toposolid_id": toposolid_id,
+            "filled_region_ids": filled_region_ids,
+            "type_name": type_name,
+        }
+        response = await revit_post("/create_toposolid_subdivision/", data, ctx)
+        return format_response(response)


### PR DESCRIPTION
## Summary
- The MCP server connected to the pyRevit Routes API using the hostname `localhost`. Changed `REVIT_HOST` in `main.py` to the explicit loopback address `127.0.0.1` to match how the Routes server is configured to bind, and to avoid any DNS/hosts-file resolution overhead.

## Test plan
- [x] Verified `BASE_URL` resolves to `http://127.0.0.1:48884/revit_mcp`
- [ ] Confirm `get_revit_status` tool call succeeds against a running pyRevit Routes server bound to 127.0.0.1