### PR TITLE
Use explicit 127.0.0.1 loopback IP for Revit Routes host

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 


### PR DESCRIPTION
## What

Change `REVIT_HOST` in `main.py` from `"localhost"` to the explicit IPv4 loopback address `"127.0.0.1"`. The `BASE_URL` the MCP server uses to reach pyRevit Routes is now `http://127.0.0.1:48884/revit_mcp`.

## Why

`localhost` can resolve to IPv6 (`::1`) on Windows, while the pyRevit Routes server binds to IPv4 (`127.0.0.1`). When that happens, the MCP server's HTTP requests can hit connection delays or outright failures. Using the explicit IPv4 loopback address removes the name-resolution ambiguity and matches the address Routes listens on by default.

## Changes

- `main.py`: `REVIT_HOST = "localhost"` → `REVIT_HOST = "127.0.0.1"` (single line).

## Notes for reviewers

- Port is unchanged (`48884`).
- Behavior is otherwise identical; this only pins the host to the IPv4 loopback.
- Verified locally: importing `main` reports `BASE_URL = http://127.0.0.1:48884/revit_mcp`, and the Routes status endpoint at that address responds `healthy`.