### PR TITLE
fix: use 127.0.0.1 instead of localhost for REVIT_HOST

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 


### PR DESCRIPTION
## Summary

- Changed `REVIT_HOST` from `"localhost"` to `"127.0.0.1"` in `main.py`

## Why

On Windows, `localhost` can resolve to the IPv6 loopback address (`::1`) depending on the system's `hosts` file or DNS resolver configuration. pyRevit Routes binds exclusively to the IPv4 address `127.0.0.1:48884`, so any client using the hostname `localhost` that resolves to `::1` will fail to connect with a connection refused error.

Using the explicit IPv4 address `127.0.0.1` ensures the HTTP client always targets the correct interface regardless of the local DNS/hosts configuration.

## Test plan

- [ ] Start Revit with pyRevit Routes enabled (port 48884)
- [ ] Run `main.py` and call any tool (e.g. `get_revit_status`)
- [ ] Confirm connection succeeds on a system where `localhost` resolves to `::1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)