### PR TITLE
Fix REVIT_HOST to use 127.0.0.1 instead of localhost

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 


### PR DESCRIPTION
localhost can resolve to ::1 (IPv6) on some Windows machines, causing connection failures to the pyRevit Routes server which binds only on 127.0.0.1. Using the literal IP avoids the ambiguity.