### PR TITLE
Use 127.0.0.1 instead of localhost for pyRevit Routes connection

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import httpx
 
-BASE_URL = "http://localhost:48884/revit_mcp"
+BASE_URL = "http://127.0.0.1:48884/revit_mcp"
 TEST_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "test.rvt")
 
 


### PR DESCRIPTION
Matches the explicit server_host = "127.0.0.1" configured in the pyRevit Routes server, avoiding any localhost resolution differences.