### PR TITLE
Use explicit 127.0.0.1 for Revit Routes host instead of localhost

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import httpx
 
-BASE_URL = "http://localhost:48884/revit_mcp"
+BASE_URL = "http://127.0.0.1:48884/revit_mcp"
 TEST_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "test.rvt")
 
 


### PR DESCRIPTION
## Summary
- The MCP server (`main.py`) and the integration test fixture (`tests/integration/conftest.py`) connected to the pyRevit Routes API using `REVIT_HOST = "localhost"`.
- Changed both to use `127.0.0.1` explicitly, matching how the local pyRevit Routes server is actually bound, and avoiding any dependency on `localhost` DNS/hosts-file resolution.
- Port (`48884`) is unchanged.

## Test plan
- [x] Confirmed `http://127.0.0.1:48884/revit_mcp/status/` responds `healthy` with Revit running and Routes enabled.
- [x] Verified the MCP server reconnects successfully to Revit through the `Revit-Connector` MCP tool set after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)