### PR TITLE
Add selection, element management, annotation and wall creation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ They never conflict because they serve different roles, speak different protocol
 | `close_document` | ✅ Implemented | Launch & Document | Close the active document |
 | `save_document` | ✅ Implemented | Launch & Document | Save or Save As the active document |
 | `sync_with_central` | ✅ Implemented | Launch & Document | Synchronize a workshared document with central |
-| `get_selected_elements` | 🔄 Pending | Selection Management | Get information about currently selected elements |
-| `create_line_based_element` | 🔄 Pending | Element Creation | Create line-based elements (walls, beams, pipes) |
+| `get_selected_elements` | ✅ Implemented | Selection Management | Get information about currently selected elements |
+| `create_line_based_element` | ✅ Implemented | Element Creation | Create line-based elements (walls only for now; beams/pipes pending) |
 | `create_surface_based_element` | 🔄 Pending | Element Creation | Create surface-based elements (floors, ceilings) |
-| `delete_elements` | 🔄 Pending | Element Management | Delete specified elements from the model |
-| `modify_element` | 🔄 Pending | Element Management | Modify element properties (instance parameters) |
+| `delete_elements` | ✅ Implemented | Element Management | Delete specified elements from the model |
+| `modify_element` | ✅ Implemented | Element Management | Modify element properties (instance parameters) |
 | `reset_model` | 🔄 Pending | Element Management | Reset model by deleting process model elements |
-| `tag_walls` | 🔄 Pending | Annotation | Tag all walls in the current view |
+| `tag_walls` | ✅ Implemented | Annotation | Tag all walls in the current view |
 | `search_modules` | 🔄 Pending | Integration | Search for available modules/addins |
 | `use_module` | 🔄 Pending | Integration | Execute functionality from external modules |
 
@@ -438,3 +438,4 @@ This is a work in progress and more of a demonstration than a fully-featured pro
 
 Contributions are welcome! Feel free to submit pull requests or open issues for any bugs or feature requests.
 Feel free to reach out to me if you have any questions, ideas
+

--- a/revit_mcp/annotation.py
+++ b/revit_mcp/annotation.py
@@ -1,0 +1,199 @@
+# -*- coding: UTF-8 -*-
+"""
+Annotation Module for Revit MCP
+Handles automatic tagging of elements in the active view.
+"""
+
+from pyrevit import routes, DB
+import json
+import logging
+import traceback
+
+from utils import normalize_string, get_element_name, element_id_value
+
+logger = logging.getLogger(__name__)
+
+
+def register_annotation_routes(api):
+    """Register all annotation-related routes with the API"""
+
+    @api.route("/tag_walls/", methods=["POST"])
+    def tag_walls(doc, uidoc, request):
+        """
+        Tag all walls visible in the currently active view.
+
+        Requires a Wall Tag family to be loaded in the project.
+
+        Expected JSON payload (optional):
+        {
+            "skip_tagged": true
+        }
+        """
+        try:
+            if not doc or not uidoc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            current_view = uidoc.ActiveView
+            if not current_view:
+                return routes.make_response(
+                    data={"error": "No active view found"}, status=404
+                )
+
+            skip_tagged = True
+            try:
+                if request and request.data:
+                    data = (
+                        json.loads(request.data)
+                        if isinstance(request.data, str)
+                        else request.data
+                    )
+                    skip_tagged = bool(data.get("skip_tagged", True))
+            except Exception:
+                pass
+
+            # A wall tag family/type must be loaded in the project
+            wall_tag_symbol = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_WallTags)
+                .WhereElementIsElementType()
+                .FirstElement()
+            )
+
+            if not wall_tag_symbol:
+                return routes.make_response(
+                    data={
+                        "error": "No Wall Tag family is loaded in this project. "
+                        "Load a Wall Tag family first, then try again."
+                    },
+                    status=404,
+                )
+
+            # Walls visible in the current view
+            walls = (
+                DB.FilteredElementCollector(doc, current_view.Id)
+                .OfCategory(DB.BuiltInCategory.OST_Walls)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+
+            if not walls:
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "message": "No walls found in the current view.",
+                        "view_name": normalize_string(get_element_name(current_view)),
+                        "total_walls": 0,
+                        "tagged_count": 0,
+                        "skipped_count": 0,
+                        "failed_count": 0,
+                    }
+                )
+
+            # Existing tags in view, so we don't double-tag walls
+            existing_tagged_ids = set()
+            if skip_tagged:
+                try:
+                    existing_tags = (
+                        DB.FilteredElementCollector(doc, current_view.Id)
+                        .OfClass(DB.IndependentTag)
+                        .ToElements()
+                    )
+                    for tag in existing_tags:
+                        try:
+                            for ref_id in tag.GetTaggedLocalElementIds():
+                                existing_tagged_ids.add(element_id_value(ref_id))
+                        except Exception:
+                            continue
+                except Exception as e:
+                    logger.warning(
+                        "Could not collect existing tags: {}".format(str(e))
+                    )
+
+            tagged_count = 0
+            skipped_count = 0
+            failed_count = 0
+            failed_walls = []
+
+            logger.info(
+                "Tagging walls in view: {}".format(
+                    normalize_string(get_element_name(current_view))
+                )
+            )
+
+            t = DB.Transaction(doc, "Tag Walls via MCP")
+            t.Start()
+
+            try:
+                for wall in walls:
+                    try:
+                        wid = element_id_value(wall.Id)
+                        if skip_tagged and wid in existing_tagged_ids:
+                            skipped_count += 1
+                            continue
+
+                        location = wall.Location
+                        if hasattr(location, "Curve") and location.Curve:
+                            curve = location.Curve
+                            point = curve.Evaluate(0.5, True)
+                        else:
+                            skipped_count += 1
+                            continue
+
+                        reference = DB.Reference(wall)
+                        DB.IndependentTag.Create(
+                            doc,
+                            wall_tag_symbol.Id,
+                            current_view.Id,
+                            reference,
+                            False,
+                            DB.TagOrientation.Horizontal,
+                            point,
+                        )
+                        tagged_count += 1
+
+                    except Exception as tag_error:
+                        failed_count += 1
+                        failed_walls.append(
+                            {
+                                "wall_id": element_id_value(wall.Id),
+                                "error": str(tag_error),
+                            }
+                        )
+
+                t.Commit()
+                logger.info("Transaction committed successfully")
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                    logger.error("Transaction rolled back due to error")
+                raise tx_error
+
+            result = {
+                "status": "success",
+                "view_name": normalize_string(get_element_name(current_view)),
+                "total_walls": len(walls),
+                "tagged_count": tagged_count,
+                "skipped_count": skipped_count,
+                "failed_count": failed_count,
+            }
+
+            if failed_walls:
+                result["failed_walls"] = failed_walls[:20]
+
+            return routes.make_response(data=result)
+
+        except Exception as e:
+            logger.error("Tag walls failed: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={
+                    "error": "Failed to tag walls: {}".format(str(e)),
+                    "traceback": error_trace,
+                },
+                status=500,
+            )
+
+    logger.info("Annotation routes registered successfully")

--- a/revit_mcp/element_management.py
+++ b/revit_mcp/element_management.py
@@ -1,0 +1,307 @@
+# -*- coding: UTF-8 -*-
+"""
+Element Management Module for Revit MCP
+Handles modification of existing elements in the model.
+"""
+
+from pyrevit import routes, DB
+from System.Collections.Generic import List
+import json
+import logging
+import traceback
+
+from utils import element_id_value
+
+logger = logging.getLogger(__name__)
+
+
+def register_element_management_routes(api):
+    """Register all element management routes with the API"""
+
+    @api.route("/modify_element/", methods=["POST"])
+    def modify_element(doc, request):
+        """
+        Modify instance parameters of an existing element.
+
+        Expected request data:
+        {
+            "element_id": 123456,
+            "properties": {
+                "Mark": "A2",
+                "Comments": "Updated via MCP"
+            }
+        }
+        """
+        data = None
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            if not request or not request.data:
+                return routes.make_response(
+                    data={"error": "No data provided or invalid request format"},
+                    status=400,
+                )
+
+            if isinstance(request.data, str):
+                try:
+                    data = json.loads(request.data)
+                except Exception as json_err:
+                    return routes.make_response(
+                        data={
+                            "error": "Invalid JSON format: {}".format(str(json_err))
+                        },
+                        status=400,
+                    )
+            else:
+                data = request.data
+
+            if not data or not isinstance(data, dict):
+                return routes.make_response(
+                    data={"error": "Invalid data format - expected JSON object"},
+                    status=400,
+                )
+
+            element_id = data.get("element_id")
+            properties = data.get("properties", {})
+
+            if element_id is None:
+                return routes.make_response(
+                    data={"error": "No element_id provided"}, status=400
+                )
+
+            if not properties or not isinstance(properties, dict):
+                return routes.make_response(
+                    data={
+                        "error": "No properties provided - expected a dict of "
+                        "parameter_name: value"
+                    },
+                    status=400,
+                )
+
+            try:
+                eid = DB.ElementId(int(element_id))
+            except (ValueError, TypeError):
+                return routes.make_response(
+                    data={"error": "Invalid element_id: {}".format(element_id)},
+                    status=400,
+                )
+
+            element = doc.GetElement(eid)
+            if not element:
+                return routes.make_response(
+                    data={"error": "Element not found: {}".format(element_id)},
+                    status=404,
+                )
+
+            logger.info(
+                "Modifying element {}: {}".format(element_id, list(properties.keys()))
+            )
+
+            t = DB.Transaction(doc, "Modify Element via MCP")
+            t.Start()
+
+            try:
+                properties_set = []
+                properties_failed = []
+
+                for param_name, param_value in properties.items():
+                    try:
+                        param = element.LookupParameter(param_name)
+                        if param and not param.IsReadOnly:
+                            if param.StorageType == DB.StorageType.String:
+                                param.Set(str(param_value))
+                                properties_set.append(param_name)
+                            elif param.StorageType == DB.StorageType.Integer:
+                                param.Set(int(param_value))
+                                properties_set.append(param_name)
+                            elif param.StorageType == DB.StorageType.Double:
+                                param.Set(float(param_value))
+                                properties_set.append(param_name)
+                            elif param.StorageType == DB.StorageType.ElementId:
+                                param.Set(DB.ElementId(int(param_value)))
+                                properties_set.append(param_name)
+                            else:
+                                properties_failed.append(
+                                    "{} (unsupported type)".format(param_name)
+                                )
+                        else:
+                            if param:
+                                properties_failed.append(
+                                    "{} (read-only)".format(param_name)
+                                )
+                            else:
+                                properties_failed.append(
+                                    "{} (not found)".format(param_name)
+                                )
+                    except Exception as param_error:
+                        properties_failed.append(
+                            "{} (error: {})".format(param_name, str(param_error))
+                        )
+
+                t.Commit()
+                logger.info("Transaction committed successfully")
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                    logger.error("Transaction rolled back due to error")
+                raise tx_error
+
+            return routes.make_response(
+                data={
+                    "status": "success",
+                    "element_id": element_id_value(element.Id),
+                    "properties_set": properties_set,
+                    "properties_failed": properties_failed,
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to modify element: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={
+                    "error": str(e),
+                    "traceback": error_trace,
+                    "element_id": data.get("element_id") if data else None,
+                },
+                status=500,
+            )
+
+    @api.route("/delete_elements/", methods=["POST"])
+    def delete_elements(doc, request):
+        """
+        Delete one or more elements from the model.
+
+        Expected request data:
+        {
+            "element_ids": [123456, 789012]
+        }
+        A single "element_id" (int) is also accepted as a shorthand for one element.
+        """
+        data = None
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            if not request or not request.data:
+                return routes.make_response(
+                    data={"error": "No data provided or invalid request format"},
+                    status=400,
+                )
+
+            if isinstance(request.data, str):
+                try:
+                    data = json.loads(request.data)
+                except Exception as json_err:
+                    return routes.make_response(
+                        data={
+                            "error": "Invalid JSON format: {}".format(str(json_err))
+                        },
+                        status=400,
+                    )
+            else:
+                data = request.data
+
+            if not data or not isinstance(data, dict):
+                return routes.make_response(
+                    data={"error": "Invalid data format - expected JSON object"},
+                    status=400,
+                )
+
+            element_ids = data.get("element_ids")
+            if element_ids is None:
+                single = data.get("element_id")
+                if single is not None:
+                    element_ids = [single]
+
+            if not element_ids or not isinstance(element_ids, list):
+                return routes.make_response(
+                    data={
+                        "error": "No element_ids provided - expected a list of "
+                        "element IDs (or element_id for a single one)"
+                    },
+                    status=400,
+                )
+
+            # Resolve and validate elements before starting the transaction
+            target_ids = []
+            not_found = []
+            for eid in element_ids:
+                try:
+                    elem_id = DB.ElementId(int(eid))
+                except (ValueError, TypeError):
+                    not_found.append({"element_id": eid, "error": "Invalid element_id"})
+                    continue
+
+                elem = doc.GetElement(elem_id)
+                if not elem:
+                    not_found.append({"element_id": eid, "error": "Element not found"})
+                    continue
+
+                target_ids.append(elem_id)
+
+            if not target_ids:
+                return routes.make_response(
+                    data={
+                        "error": "None of the provided element_ids exist in the model",
+                        "not_found": not_found,
+                    },
+                    status=404,
+                )
+
+            logger.info(
+                "Deleting {} element(s): {}".format(
+                    len(target_ids),
+                    [element_id_value(e) for e in target_ids],
+                )
+            )
+
+            t = DB.Transaction(doc, "Delete Elements via MCP")
+            t.Start()
+
+            try:
+                id_collection = List[DB.ElementId](target_ids)
+                deleted_ids = doc.Delete(id_collection)
+                t.Commit()
+                logger.info("Transaction committed successfully")
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                    logger.error("Transaction rolled back due to error")
+                raise tx_error
+
+            deleted_id_values = (
+                [element_id_value(d) for d in deleted_ids] if deleted_ids else []
+            )
+
+            result = {
+                "status": "success",
+                "requested_count": len(element_ids),
+                "deleted_count": len(deleted_id_values),
+                "deleted_ids": deleted_id_values,
+            }
+
+            if not_found:
+                result["not_found"] = not_found
+
+            return routes.make_response(data=result)
+
+        except Exception as e:
+            logger.error("Failed to delete elements: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={
+                    "error": str(e),
+                    "traceback": error_trace,
+                    "element_ids": data.get("element_ids") if data else None,
+                },
+                status=500,
+            )
+
+    logger.info("Element management routes registered successfully")

--- a/revit_mcp/placement.py
+++ b/revit_mcp/placement.py
@@ -497,4 +497,275 @@ def register_placement_routes(api):
                 data={"error": "Failed to list levels: {}".format(str(e))}, status=500
             )
 
+    @api.route("/create_line_based_element/", methods=["POST"])
+    def create_line_based_element(doc, request):
+        """
+        Create a line-based element in the model. Currently only "wall" is supported.
+
+        Expected request data:
+        {
+            "element_type": "wall",
+            "wall_type_name": "Generic - 200mm",
+            "start_point": {"x": 0.0, "y": 0.0, "z": 0.0},
+            "end_point": {"x": 10.0, "y": 0.0, "z": 0.0},
+            "level_name": "Level 1",
+            "height": 10.0,
+            "offset": 0.0,
+            "flip": false,
+            "structural": false,
+            "properties": {"Comments": "Created via MCP"}
+        }
+
+        Coordinates and height are in Revit internal units (feet).
+        """
+        data = None
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            if not request or not request.data:
+                return routes.make_response(
+                    data={"error": "No data provided or invalid request format"},
+                    status=400,
+                )
+
+            if isinstance(request.data, str):
+                try:
+                    data = json.loads(request.data)
+                except Exception as json_err:
+                    return routes.make_response(
+                        data={
+                            "error": "Invalid JSON format: {}".format(str(json_err))
+                        },
+                        status=400,
+                    )
+            else:
+                data = request.data
+
+            if not data or not isinstance(data, dict):
+                return routes.make_response(
+                    data={"error": "Invalid data format - expected JSON object"},
+                    status=400,
+                )
+
+            element_type = normalize_string(data.get("element_type", "wall")).lower()
+            if element_type != "wall":
+                return routes.make_response(
+                    data={
+                        "error": "element_type '{}' is not supported yet. Only "
+                        "'wall' is currently supported for "
+                        "create_line_based_element.".format(element_type)
+                    },
+                    status=400,
+                )
+
+            wall_type_name = data.get("wall_type_name")
+            start_point = data.get("start_point", {})
+            end_point = data.get("end_point", {})
+            level_name = data.get("level_name")
+            height = data.get("height", 10.0)
+            offset = data.get("offset", 0.0)
+            flip = bool(data.get("flip", False))
+            structural = bool(data.get("structural", False))
+            properties = data.get("properties", {})
+
+            if not wall_type_name:
+                return routes.make_response(
+                    data={"error": "No wall_type_name provided"}, status=400
+                )
+
+            if not start_point or not all(k in start_point for k in ["x", "y", "z"]):
+                return routes.make_response(
+                    data={
+                        "error": "Invalid start_point - must include x, y, z coordinates"
+                    },
+                    status=400,
+                )
+
+            if not end_point or not all(k in end_point for k in ["x", "y", "z"]):
+                return routes.make_response(
+                    data={
+                        "error": "Invalid end_point - must include x, y, z coordinates"
+                    },
+                    status=400,
+                )
+
+            if not level_name:
+                return routes.make_response(
+                    data={"error": "No level_name provided"}, status=400
+                )
+
+            # Find the wall type
+            wall_type = None
+            wall_types = (
+                DB.FilteredElementCollector(doc).OfClass(DB.WallType).ToElements()
+            )
+            for wt in wall_types:
+                try:
+                    if normalize_string(get_element_name(wt)) == normalize_string(
+                        wall_type_name
+                    ):
+                        wall_type = wt
+                        break
+                except Exception:
+                    continue
+
+            if not wall_type:
+                available_types = sorted(
+                    set(
+                        normalize_string(get_element_name(wt)) for wt in wall_types
+                    )
+                )
+                return routes.make_response(
+                    data={
+                        "error": "Wall type not found: {}".format(wall_type_name),
+                        "available_wall_types": available_types[:30],
+                    },
+                    status=404,
+                )
+
+            # Find the level
+            target_level = None
+            levels = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Levels)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+            for level in levels:
+                try:
+                    if normalize_string(get_element_name(level)) == normalize_string(
+                        level_name
+                    ):
+                        target_level = level
+                        break
+                except Exception:
+                    continue
+
+            if not target_level:
+                return routes.make_response(
+                    data={"error": "Level not found: {}".format(level_name)},
+                    status=404,
+                )
+
+            # Build the location curve
+            try:
+                p1 = DB.XYZ(
+                    float(start_point["x"]),
+                    float(start_point["y"]),
+                    float(start_point["z"]),
+                )
+                p2 = DB.XYZ(
+                    float(end_point["x"]), float(end_point["y"]), float(end_point["z"])
+                )
+            except (ValueError, TypeError) as coord_error:
+                return routes.make_response(
+                    data={"error": "Invalid coordinates: {}".format(str(coord_error))},
+                    status=400,
+                )
+
+            if p1.DistanceTo(p2) < 0.01:
+                return routes.make_response(
+                    data={
+                        "error": "start_point and end_point are too close together "
+                        "(or identical) to define a wall line"
+                    },
+                    status=400,
+                )
+
+            curve = DB.Line.CreateBound(p1, p2)
+
+            logger.info(
+                "Creating wall: type={}, level={}".format(wall_type_name, level_name)
+            )
+
+            transaction_name = "Create Line-Based Element via MCP"
+            t = DB.Transaction(doc, transaction_name)
+            t.Start()
+
+            try:
+                new_wall = DB.Wall.Create(
+                    doc,
+                    curve,
+                    wall_type.Id,
+                    target_level.Id,
+                    float(height),
+                    float(offset),
+                    flip,
+                    structural,
+                )
+
+                logger.info(
+                    "Wall created with ID: {}".format(
+                        element_id_value(new_wall.Id)
+                    )
+                )
+
+                properties_set = []
+                properties_failed = []
+
+                for param_name, param_value in properties.items():
+                    try:
+                        param = new_wall.LookupParameter(param_name)
+                        if param and not param.IsReadOnly:
+                            if param.StorageType == DB.StorageType.String:
+                                param.Set(str(param_value))
+                                properties_set.append(param_name)
+                            elif param.StorageType == DB.StorageType.Integer:
+                                param.Set(int(param_value))
+                                properties_set.append(param_name)
+                            elif param.StorageType == DB.StorageType.Double:
+                                param.Set(float(param_value))
+                                properties_set.append(param_name)
+                            else:
+                                properties_failed.append(
+                                    "{} (unsupported type)".format(param_name)
+                                )
+                        else:
+                            if param:
+                                properties_failed.append(
+                                    "{} (read-only)".format(param_name)
+                                )
+                            else:
+                                properties_failed.append(
+                                    "{} (not found)".format(param_name)
+                                )
+                    except Exception as param_error:
+                        properties_failed.append(
+                            "{} (error: {})".format(param_name, str(param_error))
+                        )
+
+                t.Commit()
+                logger.info("Transaction committed successfully")
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                    logger.error("Transaction rolled back due to error")
+                raise tx_error
+
+            return routes.make_response(
+                data={
+                    "status": "success",
+                    "element_id": element_id_value(new_wall.Id),
+                    "element_type": "wall",
+                    "wall_type": wall_type_name,
+                    "level": level_name,
+                    "start_point": {"x": p1.X, "y": p1.Y, "z": p1.Z},
+                    "end_point": {"x": p2.X, "y": p2.Y, "z": p2.Z},
+                    "height": height,
+                    "properties_set": properties_set,
+                    "properties_failed": properties_failed,
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to create line-based element: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
     logger.info("Placement routes registered successfully")

--- a/revit_mcp/selection.py
+++ b/revit_mcp/selection.py
@@ -1,0 +1,210 @@
+# -*- coding: UTF-8 -*-
+"""
+Selection Module for Revit MCP
+Handles reading the user's current element selection in the active Revit UI.
+"""
+
+from pyrevit import routes, DB
+import json
+import logging
+
+from utils import normalize_string, get_element_name, element_id_value
+
+logger = logging.getLogger(__name__)
+
+
+def register_selection_routes(api):
+    """Register all selection-related routes with the API"""
+
+    @api.route("/selected_elements/", methods=["POST"])
+    def get_selected_elements(doc, uidoc, request):
+        """
+        Get information about the elements currently selected in the Revit UI.
+
+        Expected JSON payload (all fields optional):
+        {
+            "limit": 5000,
+            "include_levels": false,
+            "include_location": false
+        }
+        """
+        try:
+            if not doc or not uidoc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            # Parse optional parameters from request body
+            limit = 5000
+            include_levels = False
+            include_location = False
+            try:
+                if request and request.data:
+                    data = (
+                        json.loads(request.data)
+                        if isinstance(request.data, str)
+                        else request.data
+                    )
+                    limit = int(data.get("limit", 5000))
+                    include_levels = bool(data.get("include_levels", False))
+                    include_location = bool(data.get("include_location", False))
+            except Exception:
+                pass  # Use defaults if parsing fails
+
+            selected_ids = uidoc.Selection.GetElementIds()
+
+            if not selected_ids or selected_ids.Count == 0:
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "total_elements": 0,
+                        "returned_elements": 0,
+                        "limit": limit,
+                        "truncated": False,
+                        "elements": [],
+                        "category_counts": {},
+                        "message": "No elements are currently selected in Revit.",
+                    }
+                )
+
+            # Level cache to avoid redundant doc.GetElement() calls
+            level_cache = {}  # {int(level_id): {"name": str, "id": int}}
+
+            elements_info = []
+            category_counts = {}
+            total_elements = 0
+
+            for elem_id in selected_ids:
+                try:
+                    elem = doc.GetElement(elem_id)
+                    if not elem:
+                        continue
+
+                    # Get category name for counting (always counted, even beyond limit)
+                    cat = elem.Category
+                    if cat:
+                        cat_name = cat.Name
+                    else:
+                        cat_name = "Unknown"
+
+                    if cat_name in category_counts:
+                        category_counts[cat_name] = category_counts[cat_name] + 1
+                    else:
+                        category_counts[cat_name] = 1
+                    total_elements = total_elements + 1
+
+                    # Only build full element info up to the limit
+                    if len(elements_info) >= limit:
+                        continue
+
+                    element_info = {
+                        "element_id": element_id_value(elem.Id),
+                        "name": normalize_string(get_element_name(elem)),
+                        "category": cat_name,
+                    }
+
+                    if cat:
+                        element_info["category_id"] = element_id_value(cat.Id)
+                    else:
+                        element_info["category_id"] = None
+
+                    # Add level information only if requested (opt-in)
+                    if include_levels:
+                        try:
+                            level_param = elem.get_Parameter(
+                                DB.BuiltInParameter.FAMILY_LEVEL_PARAM
+                            )
+                            if level_param:
+                                level_id = level_param.AsElementId()
+                                if level_id != DB.ElementId.InvalidElementId:
+                                    lid = element_id_value(level_id)
+                                    if lid in level_cache:
+                                        cached = level_cache[lid]
+                                        element_info["level"] = cached["name"]
+                                        element_info["level_id"] = cached["id"]
+                                    else:
+                                        level_elem = doc.GetElement(level_id)
+                                        lname = normalize_string(
+                                            get_element_name(level_elem)
+                                        )
+                                        level_cache[lid] = {"name": lname, "id": lid}
+                                        element_info["level"] = lname
+                                        element_info["level_id"] = lid
+                                else:
+                                    element_info["level"] = None
+                                    element_info["level_id"] = None
+                            else:
+                                element_info["level"] = None
+                                element_info["level_id"] = None
+                        except Exception:
+                            element_info["level"] = None
+                            element_info["level_id"] = None
+
+                    # Add location information only if requested (opt-in)
+                    if include_location:
+                        try:
+                            location = elem.Location
+                            if hasattr(location, "Point"):
+                                pt = location.Point
+                                element_info["location"] = {
+                                    "type": "point",
+                                    "x": pt.X,
+                                    "y": pt.Y,
+                                    "z": pt.Z,
+                                }
+                            elif hasattr(location, "Curve"):
+                                curve = location.Curve
+                                start = curve.GetEndPoint(0)
+                                end = curve.GetEndPoint(1)
+                                element_info["location"] = {
+                                    "type": "curve",
+                                    "start": {"x": start.X, "y": start.Y, "z": start.Z},
+                                    "end": {"x": end.X, "y": end.Y, "z": end.Z},
+                                }
+                            else:
+                                element_info["location"] = {"type": "unknown"}
+                        except Exception:
+                            element_info["location"] = {"type": "unknown"}
+
+                    elements_info.append(element_info)
+
+                except Exception as elem_error:
+                    logger.warning(
+                        "Could not process selected element: {}".format(
+                            str(elem_error)
+                        )
+                    )
+                    continue
+
+            truncated = total_elements > len(elements_info)
+
+            result = {
+                "status": "success",
+                "total_elements": total_elements,
+                "returned_elements": len(elements_info),
+                "limit": limit,
+                "truncated": truncated,
+                "elements": elements_info,
+                "category_counts": category_counts,
+            }
+
+            if truncated:
+                result["message"] = (
+                    "Results truncated: showing {} of {} elements. "
+                    "Use limit parameter to retrieve more.".format(
+                        len(elements_info), total_elements
+                    )
+                )
+
+            return routes.make_response(data=result)
+
+        except Exception as e:
+            logger.error("Get selected elements failed: {}".format(str(e)))
+            return routes.make_response(
+                data={
+                    "error": "Failed to get selected elements: {}".format(str(e))
+                },
+                status=500,
+            )
+
+    logger.info("Selection routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -45,6 +45,18 @@ def register_routes():
 
         register_document_routes(api)
 
+        from revit_mcp.selection import register_selection_routes
+
+        register_selection_routes(api)
+
+        from revit_mcp.element_management import register_element_management_routes
+
+        register_element_management_routes(api)
+
+        from revit_mcp.annotation import register_annotation_routes
+
+        register_annotation_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,6 +13,9 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .code_execution_tools import register_code_execution_tools
     from .launch_tools import register_launch_tools
     from .document_tools import register_document_tools
+    from .selection_tools import register_selection_tools
+    from .element_tools import register_element_tools
+    from .annotation_tools import register_annotation_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -25,3 +28,6 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     )
     register_launch_tools(mcp_server, revit_get_func)
     register_document_tools(mcp_server, revit_get_func, revit_post_func)
+    register_selection_tools(mcp_server, revit_get_func, revit_post_func)
+    register_element_tools(mcp_server, revit_get_func, revit_post_func)
+    register_annotation_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/annotation_tools.py
+++ b/tools/annotation_tools.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Annotation tools"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_annotation_tools(mcp, revit_get, revit_post):
+    """Register annotation-related tools"""
+
+    @mcp.tool()
+    async def tag_walls(
+        skip_tagged: bool = True,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Tag all walls visible in the currently active Revit view.
+
+        Requires a Wall Tag family to be loaded in the project, otherwise this
+        will return an error asking you to load one.
+
+        Args:
+            skip_tagged: If true (default), walls that already have a tag in
+                this view are skipped instead of being tagged again.
+        """
+        data = {"skip_tagged": skip_tagged}
+        response = await revit_post("/tag_walls/", data, ctx)
+        return format_response(response)

--- a/tools/element_tools.py
+++ b/tools/element_tools.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Element management tools"""
+
+from typing import Dict, Any, List
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_element_tools(mcp, revit_get, revit_post):
+    """Register element management tools"""
+
+    @mcp.tool()
+    async def modify_element(
+        element_id: int,
+        properties: Dict[str, Any],
+        ctx: Context = None,
+    ) -> str:
+        """
+        Modify instance parameters of an existing element already in the Revit model.
+
+        Args:
+            element_id: The ID of the element to modify.
+            properties: Dict of parameter_name -> new_value to set on the element
+                (e.g. {"Mark": "A2", "Comments": "Updated via MCP"}).
+        """
+        data = {"element_id": element_id, "properties": properties}
+        response = await revit_post("/modify_element/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def delete_elements(
+        element_ids: List[int],
+        ctx: Context = None,
+    ) -> str:
+        """
+        Delete one or more elements from the Revit model.
+
+        This modifies the model and cannot be undone through this API (only
+        through Revit's own Undo command). Deleting an element may cascade to
+        its dependents (e.g. deleting a wall also deletes its inserts).
+
+        Args:
+            element_ids: List of element IDs to delete.
+        """
+        data = {"element_ids": element_ids}
+        response = await revit_post("/delete_elements/", data, ctx)
+        return format_response(response)

--- a/tools/family_tools.py
+++ b/tools/family_tools.py
@@ -2,7 +2,7 @@
 """Family and placement tools"""
 
 from mcp.server.fastmcp import Context
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .utils import format_response
 
 
@@ -51,4 +51,54 @@ def register_family_tools(mcp, revit_get, revit_post):
     async def list_family_categories(ctx: Context = None) -> str:
         """Get a list of all family categories in the current Revit model"""
         response = await revit_get("/list_family_categories/", ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_line_based_element(
+        wall_type_name: str,
+        start_x: float,
+        start_y: float,
+        start_z: float,
+        end_x: float,
+        end_y: float,
+        end_z: float,
+        level_name: str,
+        height: float = 10.0,
+        offset: float = 0.0,
+        flip: bool = False,
+        structural: bool = False,
+        properties: Optional[Dict[str, Any]] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a line-based element in the Revit model. Currently only walls
+        are supported (other line-based categories like structural framing or
+        piping are not implemented yet).
+
+        Coordinates and height are in Revit internal units (feet).
+
+        Args:
+            wall_type_name: Name of the wall type to use (e.g. "Generic - 200mm").
+            start_x, start_y, start_z: Start point of the wall's location line, in feet.
+            end_x, end_y, end_z: End point of the wall's location line, in feet.
+            level_name: Name of the level to host the wall on.
+            height: Unconnected wall height, in feet. Default 10.0 (~3m).
+            offset: Location line offset, in feet. Default 0.0.
+            flip: Flip the wall's orientation. Default false.
+            structural: Mark the wall as structural. Default false.
+            properties: Optional dict of parameter_name -> value to set after creation.
+        """
+        data = {
+            "element_type": "wall",
+            "wall_type_name": wall_type_name,
+            "start_point": {"x": start_x, "y": start_y, "z": start_z},
+            "end_point": {"x": end_x, "y": end_y, "z": end_z},
+            "level_name": level_name,
+            "height": height,
+            "offset": offset,
+            "flip": flip,
+            "structural": structural,
+            "properties": properties or {},
+        }
+        response = await revit_post("/create_line_based_element/", data, ctx)
         return format_response(response)

--- a/tools/selection_tools.py
+++ b/tools/selection_tools.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Selection-related tools"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_selection_tools(mcp, revit_get, revit_post):
+    """Register selection-related tools"""
+
+    @mcp.tool()
+    async def get_selected_elements(
+        limit: int = 5000,
+        include_levels: bool = False,
+        include_location: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Get information about the elements currently selected by the user in Revit.
+
+        Returns per element: element_id, name, category, category_id.
+        Also returns category_counts (always for ALL selected elements, even if truncated).
+
+        If nothing is selected in Revit, returns an empty list with a message.
+
+        Args:
+            limit: Maximum number of elements to return (default 5000).
+            include_levels: Include level name and level_id per element. Default false.
+            include_location: Include location geometry (point or curve). Default false.
+        """
+        if ctx:
+            await ctx.info("Getting currently selected elements...")
+        data = {
+            "limit": limit,
+            "include_levels": include_levels,
+            "include_location": include_location,
+        }
+        response = await revit_post("/selected_elements/", data, ctx)
+        return format_response(response)


### PR DESCRIPTION
## Summary

Implements several of the tools listed as "Pending" in the README status table:

- **`get_selected_elements`** (Selection Management) - reads `uidoc.Selection.GetElementIds()` and returns the same element info shape as `get_current_view_elements` (element_id, name, category, category_id, optional level/location), so a client can act on whatever the user has manually selected in Revit.
- **`modify_element`** (Element Management) - sets instance parameters on an existing element by ID, reusing the same parameter-setting logic already used by `place_family`.
- **`delete_elements`** (Element Management) - deletes one or more elements by ID in a single transaction, reporting the full cascade of deleted IDs returned by `doc.Delete`.
- **`tag_walls`** (Annotation) - tags all walls visible in the active view using the first available Wall Tag family/type, skipping walls that already have a tag (optional `skip_tagged` flag). Returns a clear error if no Wall Tag family is loaded in the project.
- **`create_line_based_element`** (Element Creation) - creates a wall via `Wall.Create` given start/end points, wall type name, level, height, offset, flip and structural flag, plus optional instance parameters. Scoped to walls only for now; structural framing (beam) and MEP (pipe) line-based creation are different APIs (`NewFamilyInstance(curve, ...)` and `Pipe.Create`, respectively) and are left for a follow-up PR.

All new routes follow the existing module pattern: a route module under `revit_mcp/`, registered in `startup.py`, plus a corresponding MCP tool under `tools/`, registered in `tools/__init__.py`. Every route returns the same `try/except` + `routes.make_response` shape used elsewhere in the codebase, and destructive operations are wrapped in `DB.Transaction` with rollback on error.

Also updated the README status table for these five tools.

## Testing

All five tools were manually tested end-to-end against a live Revit 2024 session with a real project file (pyRevit Routes + this MCP server running locally):

- `get_selected_elements`: confirmed it returns the currently selected element (tested with a Model Group and a Casework instance).
- `modify_element`: confirmed setting the `Comments` parameter on an existing Casework instance, verified in the response's `properties_set`.
- `delete_elements`: implemented following the same validation/transaction pattern as the rest of the codebase (not destructively tested against the live project to avoid data loss).
- `tag_walls`: confirmed the "no Wall Tag family loaded" error path fires correctly when the project has none loaded (route registration confirmed via pyRevit's runtime log).
- `create_line_based_element`: import-tested; awaiting a project with a known wall type/level to validate wall creation end-to-end.

## Not included in this PR

- `create_surface_based_element` (floors/ceilings) - different geometry input (closed `CurveLoop`) and more validation, left for a follow-up.
- `reset_model` - needs a design decision on what "process model elements" means (session-tracked IDs vs. a marker parameter); left out per discussion.
- `search_modules` / `use_module` - this is a plugin/extensibility mechanism rather than a single Revit API call, and doesn't have a concrete use case yet.