### PR TITLE
Fix place_family failing to find families/types and accented names on Revit 2026

### DIFF
--- a/revit_mcp/placement.py
+++ b/revit_mcp/placement.py
@@ -4,7 +4,7 @@ Placement Module for Revit MCP
 Handles family placement and element creation functionality
 """
 
-from utils import get_element_name, find_family_symbol_safely, normalize_string, element_id_value
+from utils import get_element_name, find_family_symbol_safely, normalize_string, element_id_value, fix_request_string
 from pyrevit import routes, revit, DB
 import json
 import traceback
@@ -68,11 +68,16 @@ def register_placement_routes(api):
                 )
 
             # Extract required fields
-            family_name = data.get("family_name")
-            type_name = data.get("type_name")
+            # family_name/type_name/level_name are run through fix_request_string()
+            # because the Routes server mis-decodes non-ASCII request bodies (see
+            # fix_request_string's docstring) -- without it, any accented family,
+            # type, or level name silently fails to match against Revit's own
+            # (correctly decoded) element names.
+            family_name = fix_request_string(data.get("family_name"))
+            type_name = fix_request_string(data.get("type_name"))
             location = data.get("location", {})
             rotation = data.get("rotation", 0.0)
-            level_name = data.get("level_name")
+            level_name = fix_request_string(data.get("level_name"))
             properties = data.get("properties", {})
 
             # Basic validation

--- a/revit_mcp/utils.py
+++ b/revit_mcp/utils.py
@@ -60,16 +60,24 @@ def get_element_name(element):
 
 def find_family_symbol_safely(doc, target_family_name, target_type_name=None):
     """
-    Safely find a family symbol by name
-    """
-    try:
-        collector = DB.FilteredElementCollector(doc).OfClass(DB.FamilySymbol)
+    Safely find a family symbol by name.
 
-        for symbol in collector:
-            if symbol.Family.Name == target_family_name:
-                if not target_type_name or symbol.Name == target_type_name:
-                    return symbol
-        return None
-    except Exception as e:
-        logger.error("Error finding family symbol: %s", str(e))
-        return None
+    Uses get_element_name() rather than symbol.Name directly: on Revit 2026,
+    FamilySymbol.Name is not directly accessible through the IronPython
+    binding for every symbol and raises AttributeError. Without a per-symbol
+    guard, one bad symbol encountered while iterating the collector would
+    trip the function's outer except-block and abort the whole search,
+    making every lookup fail with "family not found" regardless of target.
+    """
+    collector = DB.FilteredElementCollector(doc).OfClass(DB.FamilySymbol)
+
+    for symbol in collector:
+        try:
+            if symbol.Family.Name != target_family_name:
+                continue
+            if not target_type_name or get_element_name(symbol) == target_type_name:
+                return symbol
+        except Exception as e:
+            logger.debug("Skipping symbol while searching for family: %s", str(e))
+            continue
+    return None

--- a/revit_mcp/utils.py
+++ b/revit_mcp/utils.py
@@ -35,6 +35,29 @@ def normalize_string(text):
         return u"Unnamed"
 
 
+def fix_request_string(value):
+    """Repair non-ASCII request strings mangled in transit by the Routes server.
+
+    Incoming JSON string values (e.g. family_name, type_name, level_name in
+    place_family) arrive as Python 2 `str` -- raw, *undecoded* UTF-8 bytes --
+    rather than `unicode`, e.g. "Nível" arrives as the 8 raw bytes that spell
+    "N\xc3\xadvel" instead of the single-codepoint unicode string u"N\xedvel".
+    ASCII-only values are unaffected (ASCII bytes are valid UTF-8 already,
+    and comparing str/unicode of pure-ASCII content works fine), which is
+    why this only shows up for accented/non-ASCII names when compared
+    against real Revit element names (always proper unicode from the API).
+
+    Decoding those raw bytes as UTF-8 recovers the intended text. Falls
+    back to the original value if it isn't a `str`, or isn't valid UTF-8.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        return value
+
+
 def element_id_value(element_id):
     """Get the integer value from an ElementId.
 


### PR DESCRIPTION
## Summary
Two independent bugs made `place_family` unusable on Revit 2026, both in `revit_mcp/utils.py` / `revit_mcp/placement.py`:

### 1. `find_family_symbol_safely` — any lookup returned "Family type not found"
`symbol.Name` is not accessible through the IronPython binding for every `FamilySymbol` on Revit 2026 and raises `AttributeError`. The whole search loop sat inside one outer `try/except`, so the first symbol that raised on `.Name` access aborted the entire search and the function returned `None` regardless of the actual target — `place_family` failed for every family, even ones that exist.

Fix: use the existing `get_element_name()` helper (already used elsewhere in this file, e.g. `list_families`, for the same reason) instead of `symbol.Name`, and guard each symbol individually so one bad symbol is skipped instead of failing the whole lookup.

### 2. Accented family/type/level names never matched
Separately, even after fix #1, any family, type, or level name containing non-ASCII characters (e.g. `level_name="Nível 1"`) still failed with "not found", while ASCII-only names worked fine.

Root cause: incoming JSON string values (`family_name`, `type_name`, `level_name`) arrive at the Routes handler as Python 2 `str` containing **raw, undecoded UTF-8 bytes** rather than `unicode` — e.g. "Nível" arrives as the 8 raw bytes that spell `N\xc3\xadvel` instead of the single-codepoint unicode string `u"N\xedvel"`. ASCII bytes are valid UTF-8 already (hence why ASCII-only names were unaffected), but comparing this raw-byte string against Revit's own element names (always proper unicode from the API) never matches.

Confirmed via a temporary debug route dumping `repr()` and per-character codepoints of both the incoming value and the real Revit level name: the incoming value's codepoints were exactly the UTF-8 byte sequence of the intended text (195, 173 for "í") rather than its single Unicode codepoint (237) — an un-decoded byte string, not an encoding mismatch on the Revit side.

Fix: added `fix_request_string()` to `utils.py`, which decodes these fields as UTF-8 before they're used for lookups, and applied it to `family_name`, `type_name`, and `level_name` in `place_family`.

## Test plan
- Reproduced both bugs on a real Revit 2026 project via the actual MCP → Routes → Revit round trip (not just in-process scripting).
- Bug 1: `place_family` with `family_name="M_Coluna retangular"` (ASCII, exists in model) returned 404 before the fix; succeeded after.
- Bug 2: `place_family` with `level_name="Nível 1"` (exists in model) returned 404 "Level not found" even after fix 1; succeeded after fix 2, placing and then removing a test column instance to confirm.
- `list_families` / `list_levels` were unaffected by either bug (they already used `get_element_name()` and don't do incoming-string comparisons the same way), so this doesn't change behavior elsewhere in the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)